### PR TITLE
docs: add && aidevops update to install commands

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,8 +203,8 @@
                     </div>
                     <div class="install-panels">
                         <div class="install-panel active" data-panel="bun">
-                            <button class="install-command" id="copyBtnBun" data-command="bun install -g aidevops">
-                                <span class="command-text"><span class="command-dim">bun install -g</span> <span class="command-highlight">aidevops</span></span>
+                            <button class="install-command" id="copyBtnBun" data-command="bun install -g aidevops && aidevops update">
+                                <span class="command-text"><span class="command-dim">bun install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -216,8 +216,8 @@
                             </button>
                         </div>
                         <div class="install-panel" data-panel="npm">
-                            <button class="install-command" id="copyBtnNpm" data-command="npm install -g aidevops">
-                                <span class="command-text"><span class="command-dim">npm install -g</span> <span class="command-highlight">aidevops</span></span>
+                            <button class="install-command" id="copyBtnNpm" data-command="npm install -g aidevops && aidevops update">
+                                <span class="command-text"><span class="command-dim">npm install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -229,8 +229,8 @@
                             </button>
                         </div>
                         <div class="install-panel" data-panel="brew">
-                            <button class="install-command" id="copyBtnBrew" data-command="brew tap marcusquinn/tap && brew install aidevops">
-                                <span class="command-text"><span class="command-dim">brew tap marcusquinn/tap && brew install</span> <span class="command-highlight">aidevops</span></span>
+                            <button class="install-command" id="copyBtnBrew" data-command="brew install marcusquinn/tap/aidevops && aidevops update">
+                                <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -461,8 +461,8 @@
                     </div>
                     <div class="install-panels">
                         <div class="install-panel active" data-panel="bun">
-                            <button class="install-command" data-command="bun install -g aidevops">
-                                <span class="command-text"><span class="command-dim">bun install -g</span> <span class="command-highlight">aidevops</span></span>
+                            <button class="install-command" data-command="bun install -g aidevops && aidevops update">
+                                <span class="command-text"><span class="command-dim">bun install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -474,8 +474,8 @@
                             </button>
                         </div>
                         <div class="install-panel" data-panel="npm">
-                            <button class="install-command" data-command="npm install -g aidevops">
-                                <span class="command-text"><span class="command-dim">npm install -g</span> <span class="command-highlight">aidevops</span></span>
+                            <button class="install-command" data-command="npm install -g aidevops && aidevops update">
+                                <span class="command-text"><span class="command-dim">npm install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -487,8 +487,8 @@
                             </button>
                         </div>
                         <div class="install-panel" data-panel="brew">
-                            <button class="install-command" data-command="brew tap marcusquinn/tap && brew install aidevops">
-                                <span class="command-text"><span class="command-dim">brew tap marcusquinn/tap && brew install</span> <span class="command-highlight">aidevops</span></span>
+                            <button class="install-command" data-command="brew install marcusquinn/tap/aidevops && aidevops update">
+                                <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>


### PR DESCRIPTION
Updates bun/npm/brew install commands in index.html to include `&& aidevops update` suffix, ensuring agents are deployed after package install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Installation Updates**
  * Installation commands for bun, npm, and brew now include an automatic update step upon completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->