### PR TITLE
fix: highlight both aidevops instances in install commands

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@
                     <div class="install-panels">
                         <div class="install-panel active" data-panel="bun">
                             <button class="install-command" id="copyBtnBun" data-command="bun install -g aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">bun install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
+                                <span class="command-text"><span class="command-dim">bun install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -217,7 +217,7 @@
                         </div>
                         <div class="install-panel" data-panel="npm">
                             <button class="install-command" id="copyBtnNpm" data-command="npm install -g aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">npm install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
+                                <span class="command-text"><span class="command-dim">npm install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -230,7 +230,7 @@
                         </div>
                         <div class="install-panel" data-panel="brew">
                             <button class="install-command" id="copyBtnBrew" data-command="brew install marcusquinn/tap/aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
+                                <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/</span><span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -462,7 +462,7 @@
                     <div class="install-panels">
                         <div class="install-panel active" data-panel="bun">
                             <button class="install-command" data-command="bun install -g aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">bun install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
+                                <span class="command-text"><span class="command-dim">bun install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -475,7 +475,7 @@
                         </div>
                         <div class="install-panel" data-panel="npm">
                             <button class="install-command" data-command="npm install -g aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">npm install -g aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
+                                <span class="command-text"><span class="command-dim">npm install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
@@ -488,7 +488,7 @@
                         </div>
                         <div class="install-panel" data-panel="brew">
                             <button class="install-command" data-command="brew install marcusquinn/tap/aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/aidevops &&</span> <span class="command-highlight">aidevops update</span></span>
+                                <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/</span><span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
                                         <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>


### PR DESCRIPTION
Makes both `aidevops` words green in the bun/npm/brew install commands for visual consistency.