### PR TITLE
feat: reorder installer tabs - curl first

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
                     </div>
                     <div class="install-panels">
                         <div class="install-panel active" data-panel="curl">
-                            <button class="install-command" id="copyBtn" data-command="bash <(curl -fsSL https://aidevops.sh/install)">
+                            <button class="install-command" id="copyBtnCurl" data-command="bash <(curl -fsSL https://aidevops.sh/install)">
                                 <span class="command-text"><span class="command-dim">bash &lt;(curl -fsSL</span> <span class="command-highlight">https://aidevops.sh/install</span><span class="command-dim">)</span></span>
                                 <span class="copy-status">
                                     <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">


### PR DESCRIPTION
## Summary

- Reorders installation method tabs to prioritize curl as the default
- New tab order: curl, npm, brew, bun, git
- Makes the universal curl installer the primary option for new users

## Changes

- Updated both hero and CTA section installer tabs in `index.html`
- curl tab is now active by default (was bun)
- Tab button order and panel order both updated to match

## Testing

- Verified HTML structure is valid
- Local linters passed (ShellCheck, Secretlint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installation UI updated to use a curl-based installer flow instead of the previous bun-based flow. All installation tabs, displayed commands, and copy controls across every install section were switched to the curl installer for a consistent curl-first installation experience on the page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->