### PR TITLE
fix: anchor links not working on docs.html

### DIFF
--- a/script.js
+++ b/script.js
@@ -142,20 +142,63 @@
     });
 })();
 
-// Smooth scroll for anchor links
+// Auto-generate heading IDs and smooth scroll for anchor links
 (function() {
-    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+    // Generate GitHub-style slug from heading text
+    // GitHub preserves consecutive dashes (e.g. " - " becomes "---")
+    function slugify(text) {
+        return text
+            .toLowerCase()
+            .trim()
+            .replace(/[^\w\s-]/g, '')
+            .replace(/\s+/g, '-')
+            .replace(/^-|-$/g, '');
+    }
+
+    // Add id attributes to all headings that don't have one
+    var slugCounts = {};
+    document.querySelectorAll('.docs-content h1, .docs-content h2, .docs-content h3, .docs-content h4').forEach(function(heading) {
+        if (heading.id) return;
+        var slug = slugify(heading.textContent);
+        if (!slug) return;
+        // Handle duplicate slugs by appending a counter
+        if (slugCounts[slug]) {
+            slugCounts[slug]++;
+            slug = slug + '-' + slugCounts[slug];
+        } else {
+            slugCounts[slug] = 1;
+        }
+        heading.id = slug;
+    });
+
+    // Smooth scroll for anchor links, update URL hash
+    document.querySelectorAll('a[href^="#"]').forEach(function(anchor) {
         anchor.addEventListener('click', function(e) {
-            e.preventDefault();
-            const target = document.querySelector(this.getAttribute('href'));
+            var href = this.getAttribute('href');
+            if (href === '#') {
+                e.preventDefault();
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+                history.replaceState(null, '', window.location.pathname);
+                return;
+            }
+            var target = document.querySelector(href);
             if (target) {
-                target.scrollIntoView({
-                    behavior: 'smooth',
-                    block: 'start'
-                });
+                e.preventDefault();
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                history.replaceState(null, '', href);
             }
         });
     });
+
+    // On page load, scroll to hash target if present
+    if (window.location.hash) {
+        var hashTarget = document.querySelector(window.location.hash);
+        if (hashTarget) {
+            setTimeout(function() {
+                hashTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }, 100);
+        }
+    }
 })();
 
 // Add intersection observer for fade-in animations

--- a/styles.css
+++ b/styles.css
@@ -1083,6 +1083,13 @@ body {
     line-height: 1.6;
 }
 
+.docs-content h1,
+.docs-content h2,
+.docs-content h3,
+.docs-content h4 {
+    scroll-margin-top: 5rem;
+}
+
 .docs-content h2 {
     font-size: 1.5rem;
     font-weight: 700;


### PR DESCRIPTION
## Summary

- Anchor links on https://aidevops.sh/docs.html were broken because headings lacked `id` attributes
- The smooth scroll JavaScript handler called `preventDefault()` unconditionally, silently swallowing failed navigations

## Root Cause

The docs.html page has internal links like `#ralph-loop---iterative-ai-development` and `#agent-design-patterns`, but the `<h2>`/`<h3>` elements had no `id` attributes for the browser to resolve. The JS smooth scroll handler intercepted all `#` clicks, prevented default behavior, then failed silently when `document.querySelector(href)` returned null.

## Changes

**script.js:**
- Auto-generate GitHub-style slug `id` attributes for all headings in `.docs-content` on page load
- Only `preventDefault()` when a valid target element is found (allows browser fallback)
- Handle bare `#` links (back to top) separately with smooth scroll to top
- Update `window.location.hash` via `history.replaceState` for shareable anchor URLs
- Scroll to hash target on page load for direct link support (e.g. `docs.html#mcp-integrations`)

**styles.css:**
- Add `scroll-margin-top: 5rem` to all doc headings to offset the fixed navigation bar

## Testing

All 5 anchor links referenced in docs.html now resolve correctly:
- `#agent-design-patterns`
- `#comprehensive-service-coverage`
- `#mcp-integrations`
- `#ralph-loop---iterative-ai-development`
- `#git-worktrees---parallel-branch-development`