### PR TITLE
fix: add missing security headers to _headers file

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,5 +1,11 @@
 /*
   Cache-Control: public, max-age=0, must-revalidate
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
+  Content-Security-Policy: default-src 'none'; script-src 'self' https://analytics.ahrefs.com; style-src 'self' 'sha256-zeaO0rOrQuLP2CGkGqtyd40xKjdM1wHv/fQCwOKvZ7k='; img-src 'self' https://img.shields.io https://sonarcloud.io https://app.codacy.com https://www.codefactor.io https://qlty.sh https://github.com; font-src 'self'; connect-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
 
 /*.html
   Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary

- Adds six security headers to the `/*` route in `_headers`: X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy, and Content-Security-Policy
- CSP is tailored to the site's actual resource requirements — allows Ahrefs analytics script, shields.io/SonarCloud/Codacy/CodeFactor/Qlty/GitHub badge images, and the 404.html inline style block (via SHA-256 hash)
- `default-src 'none'` with explicit allowlists for each resource type provides defense-in-depth against XSS, clickjacking, and MIME-sniffing attacks

## Headers Added

| Header | Value | Purpose |
|--------|-------|---------|
| `X-Frame-Options` | `DENY` | Prevents clickjacking |
| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing |
| `X-XSS-Protection` | `1; mode=block` | Legacy XSS filter (older browsers) |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Controls referrer leakage |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), interest-cohort=()` | Disables unused browser APIs + FLoC |
| `Content-Security-Policy` | See below | Restricts resource loading to explicit allowlist |

## CSP Breakdown

- `default-src 'none'` — deny everything not explicitly allowed
- `script-src 'self' https://analytics.ahrefs.com` — own scripts + Ahrefs analytics
- `style-src 'self' 'sha256-...'` — own stylesheets + 404.html inline style (hash-verified)
- `img-src 'self' https://img.shields.io https://sonarcloud.io https://app.codacy.com https://www.codefactor.io https://qlty.sh https://github.com` — own images + badge providers
- `font-src 'self'` / `connect-src 'self'` / `manifest-src 'self'` — self-only
- `base-uri 'self'` / `form-action 'self'` — prevent base tag hijacking and form exfiltration
- `frame-ancestors 'none'` — CSP equivalent of X-Frame-Options DENY

Relates to #10