### PR TITLE
fix: harden security headers — add HSTS, COOP, expand CSP and Permissions-Policy

### DIFF
--- a/_headers
+++ b/_headers
@@ -2,10 +2,11 @@
   Cache-Control: public, max-age=0, must-revalidate
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
-  X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
-  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=()
-  Content-Security-Policy: default-src 'none'; script-src 'self' https://analytics.ahrefs.com; style-src 'self' 'sha256-zeaO0rOrQuLP2CGkGqtyd40xKjdM1wHv/fQCwOKvZ7k='; img-src 'self' https://img.shields.io https://sonarcloud.io https://app.codacy.com https://www.codefactor.io https://qlty.sh https://github.com; font-src 'self'; connect-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Cross-Origin-Opener-Policy: same-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=(), accelerometer=(), gyroscope=(), magnetometer=(), payment=(), usb=(), autoplay=()
+  Content-Security-Policy: default-src 'none'; script-src 'self' https://analytics.ahrefs.com; style-src 'self' 'sha256-zeaO0rOrQuLP2CGkGqtyd40xKjdM1wHv/fQCwOKvZ7k='; img-src 'self' data: https://img.shields.io https://sonarcloud.io https://app.codacy.com https://www.codefactor.io https://qlty.sh https://github.com; font-src 'self'; connect-src 'self' https://analytics.ahrefs.com; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
 
 /*.html
   Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary

Hardens the `_headers` file with additional security headers and fixes CSP gaps identified in issue #14. The previous PR #11 added the initial security headers; this PR completes the hardening.

## Changes

- **Remove** deprecated `X-XSS-Protection` header — can cause XSS in older IE, OWASP recommends removal
- **Add** `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` — HSTS for HTTPS-only enforcement
- **Add** `Cross-Origin-Opener-Policy: same-origin` — prevents cross-origin window references
- **Expand** `Permissions-Policy` — added `accelerometer`, `gyroscope`, `magnetometer`, `payment`, `usb`, `autoplay` restrictions
- **CSP `img-src`**: add `data:` for data URI favicons used in `docs.html`
- **CSP `connect-src`**: add `https://analytics.ahrefs.com` for analytics beacon/XHR requests

## Verification

- Computed SHA-256 hash of 404.html inline `<style>` block — matches existing CSP hash
- Verified all 6 external image domains in CSP `img-src` against actual `<img src>` attributes across all HTML files
- Checked `Cross-Origin-Resource-Policy` headers on external badge providers — confirmed `COEP: require-corp` would break SonarCloud, CodeFactor, and Codacy badges (they don't send CORP headers), so COEP was intentionally omitted
- Confirmed Ahrefs analytics script doesn't open cross-origin windows, so `COOP: same-origin` is safe

## Not changed (intentionally)

- `COEP: require-corp` omitted — would break cross-origin badge images from providers that don't send CORP headers
- CSP SHA hash unchanged — the 404.html inline style block hasn't changed

Closes #14