### PR TITLE
refactor: deduplicate install component — clone from single source

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
                 <p class="hero-tagline">Unleash your AI assistant's true potential with specialist AI DevOps agents</p>
                 <p class="hero-description">One conversation, complete infrastructure management and a guided professional development workflow.</p>
                 
-                <div class="install-box">
+                <div class="install-box" id="install-box-source">
                     <div class="install-header">
                         <div class="install-dots">
                             <span class="dot red"></span>
@@ -463,89 +463,8 @@
         <section class="cta" id="install">
             <div class="container">
                 <h2>Get Started with AI DevOps Today</h2>
-                <div class="install-box">
-                    <div class="install-header">
-                        <div class="install-dots">
-                            <span class="dot red"></span>
-                            <span class="dot yellow"></span>
-                            <span class="dot green"></span>
-                        </div>
-                        <div class="install-tabs" role="tablist">
-                            <button class="install-tab active" role="tab" aria-selected="true" data-tab="curl">curl</button>
-                            <button class="install-tab" role="tab" aria-selected="false" data-tab="npm">npm</button>
-                            <button class="install-tab" role="tab" aria-selected="false" data-tab="brew">brew</button>
-                            <button class="install-tab" role="tab" aria-selected="false" data-tab="bun">bun</button>
-                            <button class="install-tab" role="tab" aria-selected="false" data-tab="git">git</button>
-                        </div>
-                    </div>
-                    <div class="install-panels">
-                        <div class="install-panel active" data-panel="curl">
-                            <button class="install-command" data-command="bash <(curl -fsSL https://aidevops.sh/install)">
-                                <span class="command-text"><span class="command-dim">bash &lt;(curl -fsSL</span> <span class="command-highlight">https://aidevops.sh/install</span><span class="command-dim">)</span></span>
-                                <span class="copy-status">
-                                    <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
-                                        <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
-                                    </svg>
-                                    <svg class="check-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
-                                        <path d="M2.75 15.0938L9 20.25L21.25 3.75" stroke="#B2E969"/>
-                                    </svg>
-                                </span>
-                            </button>
-                        </div>
-                        <div class="install-panel" data-panel="npm">
-                            <button class="install-command" data-command="npm install -g aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">npm install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
-                                <span class="copy-status">
-                                    <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
-                                        <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
-                                    </svg>
-                                    <svg class="check-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
-                                        <path d="M2.75 15.0938L9 20.25L21.25 3.75" stroke="#B2E969"/>
-                                    </svg>
-                                </span>
-                            </button>
-                        </div>
-                        <div class="install-panel" data-panel="brew">
-                            <button class="install-command" data-command="brew install marcusquinn/tap/aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/</span><span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
-                                <span class="copy-status">
-                                    <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
-                                        <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
-                                    </svg>
-                                    <svg class="check-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
-                                        <path d="M2.75 15.0938L9 20.25L21.25 3.75" stroke="#B2E969"/>
-                                    </svg>
-                                </span>
-                            </button>
-                        </div>
-                        <div class="install-panel" data-panel="bun">
-                            <button class="install-command" data-command="bun install -g aidevops && aidevops update">
-                                <span class="command-text"><span class="command-dim">bun install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
-                                <span class="copy-status">
-                                    <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
-                                        <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
-                                    </svg>
-                                    <svg class="check-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
-                                        <path d="M2.75 15.0938L9 20.25L21.25 3.75" stroke="#B2E969"/>
-                                    </svg>
-                                </span>
-                            </button>
-                        </div>
-                        <div class="install-panel" data-panel="git">
-                            <button class="install-command" data-command="git clone https://github.com/marcusquinn/aidevops.git ~/Git/aidevops && ~/Git/aidevops/setup.sh">
-                                <span class="command-text"><span class="command-dim">git clone</span> <span class="command-highlight">https://github.com/marcusquinn/aidevops</span></span>
-                                <span class="copy-status">
-                                    <svg class="copy-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square">
-                                        <path d="M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z"/>
-                                    </svg>
-                                    <svg class="check-icon" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="square">
-                                        <path d="M2.75 15.0938L9 20.25L21.25 3.75" stroke="#B2E969"/>
-                                    </svg>
-                                </span>
-                            </button>
-                        </div>
-                    </div>
-                </div>
+                <!-- Cloned from #install-box-source by script.js to avoid duplication -->
+                <div id="install-box-clone"></div>
             </div>
         </section>
     </main>

--- a/script.js
+++ b/script.js
@@ -45,29 +45,50 @@
     }
 })();
 
-// Install Tabs
+// Clone Install Box — single source of truth for install commands
+// The hero section (#install-box-source) is the canonical install component.
+// The CTA section (#install-box-clone) receives a deep clone so commands
+// only need to be updated in one place.
 (function() {
-    const tabs = document.querySelectorAll('.install-tab');
-    const panels = document.querySelectorAll('.install-panel');
-    
-    tabs.forEach(tab => {
-        tab.addEventListener('click', function() {
-            const targetPanel = this.dataset.tab;
-            
-            // Update tabs
-            tabs.forEach(t => {
-                t.classList.remove('active');
-                t.setAttribute('aria-selected', 'false');
-            });
-            this.classList.add('active');
-            this.setAttribute('aria-selected', 'true');
-            
-            // Update panels
-            panels.forEach(p => {
-                p.classList.remove('active');
-                if (p.dataset.panel === targetPanel) {
-                    p.classList.add('active');
-                }
+    var source = document.getElementById('install-box-source');
+    var target = document.getElementById('install-box-clone');
+    if (!source || !target) return;
+
+    var clone = source.cloneNode(true);
+    // Remove the source id to avoid duplicate IDs in the DOM
+    clone.removeAttribute('id');
+    // Strip all id attributes from cloned children (e.g. copyBtnCurl)
+    clone.querySelectorAll('[id]').forEach(function(el) {
+        el.removeAttribute('id');
+    });
+    target.replaceWith(clone);
+})();
+
+// Install Tabs — scoped per install-box so each operates independently
+(function() {
+    document.querySelectorAll('.install-box').forEach(function(box) {
+        var tabs = box.querySelectorAll('.install-tab');
+        var panels = box.querySelectorAll('.install-panel');
+
+        tabs.forEach(function(tab) {
+            tab.addEventListener('click', function() {
+                var targetPanel = this.dataset.tab;
+
+                // Update tabs within this box only
+                tabs.forEach(function(t) {
+                    t.classList.remove('active');
+                    t.setAttribute('aria-selected', 'false');
+                });
+                this.classList.add('active');
+                this.setAttribute('aria-selected', 'true');
+
+                // Update panels within this box only
+                panels.forEach(function(p) {
+                    p.classList.remove('active');
+                    if (p.dataset.panel === targetPanel) {
+                        p.classList.add('active');
+                    }
+                });
             });
         });
     });
@@ -106,40 +127,8 @@
         }, 2000);
     }
     
-    // Setup install command buttons
+    // Setup install command buttons (includes cloned CTA buttons)
     document.querySelectorAll('.install-command').forEach(setupCopyButton);
-    
-    // Setup old-style copy buttons (for CTA section)
-    document.querySelectorAll('.copy-btn').forEach(btn => {
-        btn.addEventListener('click', async function() {
-            const command = 'bash <(curl -fsSL https://aidevops.sh/install)';
-            try {
-                await navigator.clipboard.writeText(command);
-            } catch (err) {
-                const textarea = document.createElement('textarea');
-                textarea.value = command;
-                textarea.style.position = 'fixed';
-                textarea.style.opacity = '0';
-                document.body.appendChild(textarea);
-                textarea.select();
-                document.execCommand('copy');
-                document.body.removeChild(textarea);
-            }
-            
-            const copyIcon = this.querySelector('.copy-icon');
-            const checkIcon = this.querySelector('.check-icon');
-            if (copyIcon && checkIcon) {
-                copyIcon.style.display = 'none';
-                checkIcon.style.display = 'block';
-                this.classList.add('copied');
-                setTimeout(() => {
-                    copyIcon.style.display = 'block';
-                    checkIcon.style.display = 'none';
-                    this.classList.remove('copied');
-                }, 2000);
-            }
-        });
-    });
 })();
 
 // Auto-generate heading IDs and smooth scroll for anchor links


### PR DESCRIPTION
## Summary

- Replaces the duplicated install-box in the CTA section with a JS deep-clone of the hero install-box, establishing a single source of truth for install commands
- Scopes tab switching per install-box so each operates independently (previously all tabs on the page were coupled)
- Removes dead `.copy-btn` handler that was leftover from a previous CTA implementation

## Details

**Problem:** The install component (5 tabs: curl/npm/brew/bun/git with copy-to-clipboard) was fully duplicated in `index.html` — once in the hero section (lines 189-271) and again in the CTA section (lines 466-548). Any command update had to be made in two places, risking inconsistency.

**Solution:** The hero install-box is now the canonical source (`id="install-box-source"`). The CTA section contains only a `<div id="install-box-clone"></div>` placeholder. On page load, `script.js` deep-clones the source into the placeholder, strips duplicate IDs, and the existing tab/copy handlers wire up to both instances automatically.

**Net effect:** -92 lines of duplicated HTML, +18 lines of JS cloning logic. Future install command changes only need to be made once.

Closes #26