### PR TITLE
t018: fix MODELS.md routing tier model name inconsistencies

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -38,9 +38,9 @@ Active model assignments for each dispatch tier:
 | Tier | Primary Model | Relative Cost |
 |------|---------------|---------------|
 | haiku | claude-haiku-4-5 | ~0.33x |
-| flash | gemini-2.5-flash-preview-05-20 | ~0.20x |
+| flash | gemini-2.5-flash | ~0.20x |
 | sonnet | claude-sonnet-4-6 | 1x (baseline) |
-| pro | gemini-2.5-pro-preview-06-05 | ~1.5x |
+| pro | gemini-2.5-pro | ~1.5x |
 | opus | claude-opus-4-6 | ~1.7x |
 
 ## Performance Leaderboard


### PR DESCRIPTION
## Summary

- Normalize routing tier model names in MODELS.md to match the Available Models table
- `gemini-2.5-flash-preview-05-20` → `gemini-2.5-flash`
- `gemini-2.5-pro-preview-06-05` → `gemini-2.5-pro`

## Review Findings Addressed

| # | Severity | Reviewer | Finding | Status |
|---|----------|----------|---------|--------|
| 1 | HIGH | CodeRabbit | TOON summary stale zeros (TODO.md:96) | Already fixed in prior commits |
| 2 | MEDIUM | Gemini | TOON:backlog vs human-readable mismatch (TODO.md:61) | Already fixed (t001 moved to Done) |
| 3 | MEDIUM | CodeRabbit | Routing tier model names inconsistent (MODELS.md:41,43) | **Fixed in this PR** |
| 4 | MINOR | CodeRabbit | Typo "inventin" in PLANS.md:40 | Already fixed in PR #13 commits |

Only finding #3 remained unaddressed — the other three were resolved in subsequent commits after PR #13 merged.

Closes #18