### PR TITLE
t016: fix premature HSTS preload directive

### DIFF
--- a/_headers
+++ b/_headers
@@ -3,7 +3,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
   Cross-Origin-Opener-Policy: same-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=(), accelerometer=(), gyroscope=(), magnetometer=(), payment=(), usb=(), autoplay=()
   Content-Security-Policy: default-src 'none'; script-src 'self' https://analytics.ahrefs.com; style-src 'self' 'sha256-zeaO0rOrQuLP2CGkGqtyd40xKjdM1wHv/fQCwOKvZ7k='; img-src 'self' data: https://img.shields.io https://sonarcloud.io https://app.codacy.com https://www.codefactor.io https://qlty.sh https://github.com; font-src 'self'; connect-src 'self' https://analytics.ahrefs.com; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'


### PR DESCRIPTION
## Summary

- Remove `preload` from `Strict-Transport-Security` header — domain is not on the HSTS preload list (`hstspreload.org` status: `unknown`), making the directive premature and a risk per Gemini review on PR #15
- HSTS remains fully active with `max-age=31536000; includeSubDomains` — HTTPS enforcement is unchanged
- CSP `report-to`/`report-uri` not added — requires a reporting endpoint service not yet configured for this static site (documented as future enhancement)

## Context

Addresses both findings from the Gemini code review on PR #15:

1. **HSTS `preload` (MEDIUM)**: The `preload` directive signals intent to be added to browser preload lists, but `aidevops.sh` was never submitted to `hstspreload.org`. Once on the list, removal is difficult and requires all subdomains to permanently support HTTPS. Removing `preload` now preserves the option to add it later after proper submission.

2. **CSP `report-to` (MEDIUM)**: Adding violation reporting requires a backend endpoint (Sentry, Report-URI, etc.). This is a static site on Cloudflare Pages with no backend. Adding a placeholder URL would be misleading. This is deferred until a reporting service is configured.

## Verification

- Confirmed domain status via `hstspreload.org` API: `{"status": "unknown"}`
- Remaining HSTS header (`max-age=31536000; includeSubDomains`) follows current best practices
- All other security headers reviewed — no additional changes needed

Closes #16