### PR TITLE
t016: Fix quality-debt in _headers from PR #15 review feedback

### DIFF
--- a/_headers
+++ b/_headers
@@ -3,7 +3,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
   Cross-Origin-Opener-Policy: same-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=(), accelerometer=(), gyroscope=(), magnetometer=(), payment=(), usb=(), autoplay=()
   Content-Security-Policy: default-src 'none'; script-src 'self' https://analytics.ahrefs.com; style-src 'self' 'sha256-zeaO0rOrQuLP2CGkGqtyd40xKjdM1wHv/fQCwOKvZ7k='; img-src 'self' data: https://img.shields.io https://sonarcloud.io https://app.codacy.com https://www.codefactor.io https://qlty.sh https://github.com; font-src 'self'; connect-src 'self' https://analytics.ahrefs.com; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'


### PR DESCRIPTION
## Summary

Addresses quality-debt findings from PR #15 review feedback (issue #16).

### Finding 1: HSTS `preload` directive (FIXED)

Removed `preload` from the `Strict-Transport-Security` header. The domain `aidevops.sh` has **not been submitted** to the [HSTS preload list](https://hstspreload.org) (API status: `unknown`). The `preload` directive is a significant long-term commitment — once on the list, removal is difficult and all subdomains must permanently support HTTPS.

**Action**: Removed `preload`. HSTS remains strong with `max-age=31536000; includeSubDomains`. The directive can be re-added after the domain is actually submitted to hstspreload.org.

### Finding 2: CSP `report-to`/`report-uri` (DISMISSED)

The reviewer suggested adding CSP violation reporting. This requires a reporting endpoint (Sentry CSP, Report-URI service, etc.). This is a static site on Cloudflare Pages with no server-side component or reporting service configured. Adding a non-functional endpoint would be misleading.

**Dismissal reason**: No reporting endpoint available for this static site. When a CSP reporting service is set up in the future, the `report-to` directive should be added at that time.

Closes #16