### PR TITLE
fix: replace inline SVG favicon with proper favicon link set in docs.html

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -37,7 +37,13 @@
     <meta name="application-name" content="AI DevOps">
     
     <link rel="stylesheet" href="styles.css">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512'><path fill='%23B2E969' d='M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416H544c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32s14.3-32 32-32z'/></svg>">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="manifest" href="/site.webmanifest">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary

- Replace the old inline SVG data URI favicon in `docs.html` with the proper favicon link set (apple-touch-icon, SVG, PNG 48/32/16, ICO, webmanifest)
- Brings `docs.html` into consistency with `index.html` and `404.html`, which were already updated
- Addresses Gemini code review feedback from PR #2: prioritize SVG format, include `favicon-48x48.png`

Closes #28