### PR TITLE
fix: add HSTS preload directive to security headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -3,7 +3,7 @@
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
-  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Cross-Origin-Opener-Policy: same-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=(), accelerometer=(), gyroscope=(), magnetometer=(), payment=(), usb=(), autoplay=()
   Content-Security-Policy: default-src 'none'; script-src 'self' https://analytics.ahrefs.com; style-src 'self' 'sha256-zeaO0rOrQuLP2CGkGqtyd40xKjdM1wHv/fQCwOKvZ7k='; img-src 'self' data: https://img.shields.io https://sonarcloud.io https://app.codacy.com https://www.codefactor.io https://qlty.sh https://github.com; font-src 'self'; connect-src 'self' https://analytics.ahrefs.com; manifest-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'


### PR DESCRIPTION
## Summary

- Adds `preload` to the `Strict-Transport-Security` header, enabling HSTS preload list eligibility for stronger HTTPS enforcement against SSL stripping attacks

## Gemini Review Findings Disposition (Issue #20)

| # | Finding | Severity | Status | Rationale |
|---|---------|----------|--------|-----------|
| 1 | HSTS header missing | medium | **Fixed in this PR** | Added `preload` directive to existing HSTS header |
| 2 | CSP too restrictive (`img-src`, `connect-src`) | medium | Already fixed | `data:` in `img-src` and Ahrefs in `connect-src` were addressed in a prior commit |
| 3 | JSON-LD blocked by `script-src` | medium | **Dismissed — false positive** | `<script type="application/ld+json">` is a data block; browsers do not enforce CSP `script-src` on non-executable script types per CSP Level 3 spec |
| 4 | `X-XSS-Protection` deprecated | medium | Already fixed | Removed in a prior commit |

## Verification

- Inline style SHA-256 hash verified: matches `404.html` `<style>` block
- All badge image domains present in `img-src`
- Ahrefs analytics allowed in both `script-src` and `connect-src`

Closes #20