### PR TITLE
fix: use semantic ul/li for supported tools list (#23)

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,21 +287,15 @@
 
                 <div class="supported-tools">
                     <span class="supported-tools-label">Works with:</span>
-                    <div class="supported-tools-list">
-                        <a href="https://opencode.ai" target="_blank" rel="noopener noreferrer">OpenCode</a>
-                        <span class="tool-separator">/</span>
-                        <a href="https://docs.anthropic.com/en/docs/claude-code/setup" target="_blank" rel="noopener noreferrer">Claude Code</a>
-                        <span class="tool-separator">/</span>
-                        <a href="https://developers.openai.com/codex/cli" target="_blank" rel="noopener noreferrer">Codex CLI</a>
-                        <span class="tool-separator">/</span>
-                        <a href="https://cursor.com" target="_blank" rel="noopener noreferrer">Cursor</a>
-                        <span class="tool-separator">/</span>
-                        <a href="https://github.com/features/copilot" target="_blank" rel="noopener noreferrer">GitHub Copilot</a>
-                        <span class="tool-separator">/</span>
-                        <a href="https://zed.dev" target="_blank" rel="noopener noreferrer">Zed</a>
-                        <span class="tool-separator">/</span>
-                        <a href="https://codeium.com/windsurf" target="_blank" rel="noopener noreferrer">Windsurf</a>
-                    </div>
+                    <ul class="supported-tools-list" role="list">
+                        <li><a href="https://opencode.ai" target="_blank" rel="noopener noreferrer">OpenCode</a></li>
+                        <li><a href="https://docs.anthropic.com/en/docs/claude-code/setup" target="_blank" rel="noopener noreferrer">Claude Code</a></li>
+                        <li><a href="https://developers.openai.com/codex/cli" target="_blank" rel="noopener noreferrer">Codex CLI</a></li>
+                        <li><a href="https://cursor.com" target="_blank" rel="noopener noreferrer">Cursor</a></li>
+                        <li><a href="https://github.com/features/copilot" target="_blank" rel="noopener noreferrer">GitHub Copilot</a></li>
+                        <li><a href="https://zed.dev" target="_blank" rel="noopener noreferrer">Zed</a></li>
+                        <li><a href="https://codeium.com/windsurf" target="_blank" rel="noopener noreferrer">Windsurf</a></li>
+                    </ul>
                 </div>
             </div>
         </section>

--- a/styles.css
+++ b/styles.css
@@ -537,6 +537,15 @@ body {
     align-items: center;
     gap: 0.25rem;
     font-size: 0.9rem;
+    list-style: none;
+    padding: 0;
+}
+
+.supported-tools-list li:not(:last-child)::after {
+    content: '/';
+    color: var(--text-muted);
+    opacity: 0.5;
+    margin-left: 0.25rem;
 }
 
 .supported-tools-list a {
@@ -550,11 +559,6 @@ body {
 .supported-tools-list a:hover,
 .supported-tools-list a:focus {
     color: var(--accent);
-}
-
-.tool-separator {
-    color: var(--text-muted);
-    opacity: 0.5;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary

- Converts the "Works with" tools list from `<div>` + `<span class="tool-separator">` markup to a semantic `<ul>` with `<li>` elements and `role="list"`
- Replaces inline separator `<span>` elements with CSS `::after` pseudo-elements on `li:not(:last-child)`, reducing markup and improving maintainability
- Improves accessibility for screen readers by using proper list semantics

Closes #23

**Source**: Gemini code review feedback on PR #5 (medium severity)