### PR TITLE
t050: use getElementById instead of querySelector for anchor navigation

### DIFF
--- a/script.js
+++ b/script.js
@@ -183,7 +183,7 @@
                 history.replaceState(null, '', window.location.pathname);
                 return;
             }
-            const target = document.querySelector(href);
+            const target = document.getElementById(href.slice(1));
             if (target) {
                 e.preventDefault();
                 target.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -196,7 +196,7 @@
     // are loaded so layout is stable and scrollIntoView positions correctly.
     window.addEventListener('load', () => {
         if (window.location.hash) {
-            const hashTarget = document.querySelector(window.location.hash);
+            const hashTarget = document.getElementById(window.location.hash.slice(1));
             if (hashTarget) {
                 hashTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
             }


### PR DESCRIPTION
## Summary

- Replace `document.querySelector(href)` with `document.getElementById(href.slice(1))` at line 186 for smooth-scroll anchor links
- Replace `document.querySelector(window.location.hash)` with `document.getElementById(window.location.hash.slice(1))` at line 199 for on-load hash scrolling

## Why

`querySelector` interprets CSS meta-characters (`.`, `:`, `[`, etc.) in the selector string. If a heading ID contains any of these characters, `querySelector` will misparse the selector and fail to find the element. `getElementById` treats the argument as a literal ID string and handles any character correctly.

Both findings were flagged as **high severity** by Gemini Code Assist in PR #32 review feedback.

Closes #50