### PR TITLE
t049: Add keyboard navigation to install tab widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,11 +204,11 @@
                             <span class="dot green"></span>
                         </div>
                         <div class="install-tabs" role="tablist">
-                            <button class="install-tab active" role="tab" aria-selected="true" aria-controls="panel-curl" id="tab-curl" data-tab="curl">curl</button>
-                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-npm" id="tab-npm" data-tab="npm">npm</button>
-                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-brew" id="tab-brew" data-tab="brew">brew</button>
-                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-bun" id="tab-bun" data-tab="bun">bun</button>
-                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-git" id="tab-git" data-tab="git">git</button>
+                            <button class="install-tab active" role="tab" aria-selected="true" aria-controls="panel-curl" id="tab-curl" tabindex="0" data-tab="curl">curl</button>
+                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-npm" id="tab-npm" tabindex="-1" data-tab="npm">npm</button>
+                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-brew" id="tab-brew" tabindex="-1" data-tab="brew">brew</button>
+                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-bun" id="tab-bun" tabindex="-1" data-tab="bun">bun</button>
+                            <button class="install-tab" role="tab" aria-selected="false" aria-controls="panel-git" id="tab-git" tabindex="-1" data-tab="git">git</button>
                         </div>
                     </div>
                     <div class="install-panels">
@@ -221,7 +221,7 @@
                                 </span>
                             </button>
                         </div>
-                        <div class="install-panel" data-panel="npm" role="tabpanel" id="panel-npm" aria-labelledby="tab-npm">
+                        <div class="install-panel" data-panel="npm" role="tabpanel" id="panel-npm" aria-labelledby="tab-npm" aria-hidden="true">
                             <button class="install-command" id="copyBtnNpm" data-command="npm install -g aidevops && aidevops update">
                                 <span class="command-text"><span class="command-dim">npm install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
@@ -230,7 +230,7 @@
                                 </span>
                             </button>
                         </div>
-                        <div class="install-panel" data-panel="brew" role="tabpanel" id="panel-brew" aria-labelledby="tab-brew">
+                        <div class="install-panel" data-panel="brew" role="tabpanel" id="panel-brew" aria-labelledby="tab-brew" aria-hidden="true">
                             <button class="install-command" id="copyBtnBrew" data-command="brew install marcusquinn/tap/aidevops && aidevops update">
                                 <span class="command-text"><span class="command-dim">brew install marcusquinn/tap/</span><span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
@@ -239,7 +239,7 @@
                                 </span>
                             </button>
                         </div>
-                        <div class="install-panel" data-panel="bun" role="tabpanel" id="panel-bun" aria-labelledby="tab-bun">
+                        <div class="install-panel" data-panel="bun" role="tabpanel" id="panel-bun" aria-labelledby="tab-bun" aria-hidden="true">
                             <button class="install-command" id="copyBtnBun" data-command="bun install -g aidevops && aidevops update">
                                 <span class="command-text"><span class="command-dim">bun install -g</span> <span class="command-highlight">aidevops</span> <span class="command-dim">&&</span> <span class="command-highlight">aidevops</span> <span class="command-dim">update</span></span>
                                 <span class="copy-status">
@@ -248,7 +248,7 @@
                                 </span>
                             </button>
                         </div>
-                        <div class="install-panel" data-panel="git" role="tabpanel" id="panel-git" aria-labelledby="tab-git">
+                        <div class="install-panel" data-panel="git" role="tabpanel" id="panel-git" aria-labelledby="tab-git" aria-hidden="true">
                             <button class="install-command" id="copyBtnGit" data-command="git clone https://github.com/marcusquinn/aidevops.git ~/Git/aidevops && ~/Git/aidevops/setup.sh">
                                 <span class="command-text"><span class="command-dim">git clone</span> <span class="command-highlight">https://github.com/marcusquinn/aidevops</span></span>
                                 <span class="copy-status">

--- a/script.js
+++ b/script.js
@@ -76,33 +76,83 @@
     target.replaceWith(clone);
 })();
 
-// Install Tabs — scoped per install-box so each operates independently
+// Install Tabs — WAI-ARIA tabs pattern with keyboard navigation
+// Implements roving tabindex, Arrow Left/Right (wrapping), Home/End,
+// and Enter/Space activation per WAI-ARIA Authoring Practices.
+// Scoped per install-box so hero and CTA clones operate independently.
 (function() {
     document.querySelectorAll('.install-box').forEach((box) => {
-        const tabs = box.querySelectorAll('.install-tab');
+        const tabs = Array.from(box.querySelectorAll('.install-tab'));
         const panels = box.querySelectorAll('.install-panel');
 
+        // Activate a tab: update ARIA state, roving tabindex, panels, and focus
+        const activateTab = (tab, moveFocus) => {
+            const targetPanel = tab.dataset.tab;
+
+            // Deactivate all tabs in this box
+            tabs.forEach((t) => {
+                t.classList.remove('active');
+                t.setAttribute('aria-selected', 'false');
+                t.setAttribute('tabindex', '-1');
+            });
+
+            // Activate the target tab
+            tab.classList.add('active');
+            tab.setAttribute('aria-selected', 'true');
+            tab.setAttribute('tabindex', '0');
+
+            // Switch panels and update aria-hidden
+            panels.forEach((p) => {
+                const isTarget = p.dataset.panel === targetPanel;
+                p.classList.toggle('active', isTarget);
+                if (isTarget) {
+                    p.removeAttribute('aria-hidden');
+                } else {
+                    p.setAttribute('aria-hidden', 'true');
+                }
+            });
+
+            if (moveFocus) {
+                tab.focus();
+            }
+        };
+
+        // Click handler — activate on click (mouse or implicit Enter/Space on button)
         tabs.forEach((tab) => {
             tab.addEventListener('click', () => {
-                const targetPanel = tab.dataset.tab;
-
-                // Update tabs within this box only
-                tabs.forEach((t) => {
-                    t.classList.remove('active');
-                    t.setAttribute('aria-selected', 'false');
-                });
-                tab.classList.add('active');
-                tab.setAttribute('aria-selected', 'true');
-
-                // Update panels within this box only
-                panels.forEach((p) => {
-                    p.classList.remove('active');
-                    if (p.dataset.panel === targetPanel) {
-                        p.classList.add('active');
-                    }
-                });
+                activateTab(tab, false);
             });
         });
+
+        // Keyboard handler on the tablist for arrow navigation
+        const tablist = box.querySelector('[role="tablist"]');
+        if (tablist) {
+            tablist.addEventListener('keydown', (e) => {
+                const currentIndex = tabs.indexOf(e.target);
+                if (currentIndex === -1) return;
+
+                let nextIndex;
+                switch (e.key) {
+                    case 'ArrowRight':
+                        nextIndex = (currentIndex + 1) % tabs.length;
+                        break;
+                    case 'ArrowLeft':
+                        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+                        break;
+                    case 'Home':
+                        nextIndex = 0;
+                        break;
+                    case 'End':
+                        nextIndex = tabs.length - 1;
+                        break;
+                    default:
+                        return; // Let other keys propagate normally
+                }
+
+                e.preventDefault();
+                activateTab(tabs[nextIndex], true);
+            });
+        }
     });
 })();
 


### PR DESCRIPTION
## Summary

- Implements full WAI-ARIA tabs keyboard contract (ArrowLeft/Right with wrapping, Home/End) for the install method tab widget
- Adds roving tabindex so only the active tab is in the tab order, and `aria-hidden` on inactive panels
- Refactors tab activation into a shared function used by both click and keyboard handlers

Closes #49

## Details

The tab widget in `index.html` had proper ARIA roles (`role="tab"`, `role="tabpanel"`, `aria-selected`, `aria-controls`, `aria-labelledby`) added in PR #38, but `script.js` only handled click events. Keyboard users could not navigate between tabs using arrow keys, which is the expected behavior for an ARIA tab interface.

### Changes

**`index.html`:**
- Added `tabindex="0"` to the active tab button, `tabindex="-1"` to inactive tabs (roving tabindex)
- Added `aria-hidden="true"` to inactive tab panels

**`script.js`:**
- Extracted `activateTab(tab, moveFocus)` function that handles all state updates: `aria-selected`, `tabindex`, `active` class, `aria-hidden` on panels, and optional focus management
- Click handler delegates to `activateTab` (Enter/Space handled natively by `<button>` elements)
- Added `keydown` listener on the `[role="tablist"]` element for ArrowRight, ArrowLeft (both wrap), Home, and End
- Both hero and CTA clone install boxes get independent handlers (scoped per `.install-box`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install tabs now support full keyboard navigation: use arrow keys (left and right with automatic wrapping), Home key to jump to the first tab, and End key for the last tab.
  * Improved accessibility support for screen readers and assistive technology users through enhanced ARIA attributes and better focus management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->