### PR TITLE
t047: combine clone ID/ARIA prefixing into single loop with empty-id guard

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,18 +59,18 @@
     const clone = source.cloneNode(true);
     const PREFIX = 'cta-';
 
-    // Re-prefix all IDs so the clone has its own unique set
+    // Re-prefix IDs and update ARIA cross-references in a single pass
     clone.removeAttribute('id');
-    clone.querySelectorAll('[id]').forEach((el) => {
-        el.id = PREFIX + el.id;
-    });
-
-    // Update ARIA cross-references to match the new IDs
-    clone.querySelectorAll('[aria-controls]').forEach((el) => {
-        el.setAttribute('aria-controls', PREFIX + el.getAttribute('aria-controls'));
-    });
-    clone.querySelectorAll('[aria-labelledby]').forEach((el) => {
-        el.setAttribute('aria-labelledby', PREFIX + el.getAttribute('aria-labelledby'));
+    clone.querySelectorAll('[id], [aria-controls], [aria-labelledby]').forEach((el) => {
+        if (el.id) {
+            el.id = PREFIX + el.id;
+        }
+        if (el.hasAttribute('aria-controls')) {
+            el.setAttribute('aria-controls', PREFIX + el.getAttribute('aria-controls'));
+        }
+        if (el.hasAttribute('aria-labelledby')) {
+            el.setAttribute('aria-labelledby', PREFIX + el.getAttribute('aria-labelledby'));
+        }
     });
 
     target.replaceWith(clone);


### PR DESCRIPTION
## Summary

- Merges three separate `querySelectorAll` loops (for `[id]`, `[aria-controls]`, `[aria-labelledby]`) into a single combined selector loop
- Adds a truthy check on `el.id` to prevent creating bare `cta-` prefixed IDs from elements with empty `id=""` attributes
- Zero behavioural change for well-formed HTML; improves efficiency (1 DOM traversal instead of 3) and robustness against edge cases

## Details

**Source:** Gemini Code Assist review on PR #41 ([comment](https://github.com/marcusquinn/aidevops.sh/pull/41#discussion_r2896858074)), tracked as quality-debt issue #47.

**Before:** Three separate loops each calling `querySelectorAll` on the cloned DOM:
```js
clone.querySelectorAll('[id]').forEach(...)
clone.querySelectorAll('[aria-controls]').forEach(...)
clone.querySelectorAll('[aria-labelledby]').forEach(...)
```

**After:** Single combined selector with attribute-presence guards:
```js
clone.querySelectorAll('[id], [aria-controls], [aria-labelledby]').forEach((el) => {
    if (el.id) { el.id = PREFIX + el.id; }
    if (el.hasAttribute('aria-controls')) { ... }
    if (el.hasAttribute('aria-labelledby')) { ... }
});
```

Closes #47