### PR TITLE
fix: remove redundant role="list" from ul element (#45)

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
 
                 <div class="supported-tools">
                     <span class="supported-tools-label">Works with:</span>
-                    <ul class="supported-tools-list" role="list">
+                    <ul class="supported-tools-list">
                         <li><a href="https://opencode.ai" target="_blank" rel="noopener noreferrer">OpenCode</a></li>
                         <li><a href="https://docs.anthropic.com/en/docs/claude-code/setup" target="_blank" rel="noopener noreferrer">Claude Code</a></li>
                         <li><a href="https://developers.openai.com/codex/cli" target="_blank" rel="noopener noreferrer">Codex CLI</a></li>


### PR DESCRIPTION
## Summary

- Removes the redundant `role="list"` attribute from the `<ul>` element at line 290 of `index.html`
- The `<ul>` element has an implicit ARIA role of `list` by default, so the explicit attribute is unnecessary
- Relies on native HTML semantics, which is best practice for accessibility and maintainability

Per Gemini code review feedback on PR #44 ([comment](https://github.com/marcusquinn/aidevops.sh/pull/44#discussion_r2897264530)).

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved HTML semantic structure for better code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->