### PR TITLE
t047: combine clone DOM loops into single pass with empty-id guard

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,18 +59,18 @@
     const clone = source.cloneNode(true);
     const PREFIX = 'cta-';
 
-    // Re-prefix all IDs so the clone has its own unique set
+    // Re-prefix IDs and update ARIA cross-references in a single pass
     clone.removeAttribute('id');
-    clone.querySelectorAll('[id]').forEach((el) => {
-        el.id = PREFIX + el.id;
-    });
-
-    // Update ARIA cross-references to match the new IDs
-    clone.querySelectorAll('[aria-controls]').forEach((el) => {
-        el.setAttribute('aria-controls', PREFIX + el.getAttribute('aria-controls'));
-    });
-    clone.querySelectorAll('[aria-labelledby]').forEach((el) => {
-        el.setAttribute('aria-labelledby', PREFIX + el.getAttribute('aria-labelledby'));
+    clone.querySelectorAll('[id], [aria-controls], [aria-labelledby]').forEach((el) => {
+        if (el.id) {
+            el.id = PREFIX + el.id;
+        }
+        if (el.hasAttribute('aria-controls')) {
+            el.setAttribute('aria-controls', PREFIX + el.getAttribute('aria-controls'));
+        }
+        if (el.hasAttribute('aria-labelledby')) {
+            el.setAttribute('aria-labelledby', PREFIX + el.getAttribute('aria-labelledby'));
+        }
     });
 
     target.replaceWith(clone);


### PR DESCRIPTION
## Summary

- Combines 3 separate `querySelectorAll` DOM traversals into a single loop using `[id], [aria-controls], [aria-labelledby]` compound selector
- Adds `el.id` truthiness guard to prevent creating orphan `cta-` prefixed IDs from empty `id=""` attributes
- Zero behavioural change for well-formed markup; fixes edge case with empty id attributes

## Details

**Problem:** PR #41 modernized syntax but left 3 separate DOM loops iterating over the cloned install-box element. Gemini Code Assist flagged this as medium-severity: inefficient (3 traversals instead of 1) and fragile (empty `id=""` attributes would produce `cta-` orphan IDs).

**Fix:** Single `querySelectorAll('[id], [aria-controls], [aria-labelledby]')` loop with conditional checks per attribute. Each element is visited once; attributes are only modified if present.

Closes #47