### PR TITLE
docs: extend service integrations list

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,7 @@
         <section class="services" id="services">
             <div class="container">
                 <h2 class="section-title">AI DevOps Service Integrations</h2>
+                <p class="section-subtitle">aidevops connects your agents to the infrastructure, developer platforms, quality tools, document workflows, communications channels, creative systems, and local automation services that make delivery happen.</p>
                 <div class="services-grid">
                     <div class="service-category">
                         <h3>Hosting</h3>
@@ -365,6 +366,7 @@
                             <li><a href="https://coolify.io/" target="_blank" rel="noopener noreferrer">Coolify</a></li>
                             <li><a href="https://www.marcusquinn.com/link/cloudron" target="_blank" rel="noopener noreferrer">Cloudron</a></li>
                             <li><a href="https://vercel.com/" target="_blank" rel="noopener noreferrer">Vercel</a></li>
+                            <li><a href="https://aws.amazon.com/" target="_blank" rel="noopener noreferrer">AWS</a></li>
                             <li><a href="https://www.digitalocean.com/" target="_blank" rel="noopener noreferrer">DigitalOcean</a></li>
                             <li><a href="https://aws.amazon.com/ses/" target="_blank" rel="noopener noreferrer">AWS SES</a></li>
                         </ul>
@@ -375,17 +377,20 @@
                             <li><a href="https://www.cloudflare.com/" target="_blank" rel="noopener noreferrer">Cloudflare</a></li>
                             <li><a href="https://www.spaceship.com/" target="_blank" rel="noopener noreferrer">Spaceship</a></li>
                             <li><a href="https://www.marcusquinn.com/link/101domain" target="_blank" rel="noopener noreferrer">101domains</a></li>
-
+                            <li><a href="https://aws.amazon.com/route53/" target="_blank" rel="noopener noreferrer">AWS Route 53</a></li>
                             <li><a href="https://www.marcusquinn.com/link/namecheap" target="_blank" rel="noopener noreferrer">Namecheap</a></li>
                         </ul>
                     </div>
                     <div class="service-category">
-                        <h3>Development &amp; Git</h3>
+                        <h3>Development, Git &amp; Agents</h3>
                         <ul>
                             <li><a href="https://github.com/" target="_blank" rel="noopener noreferrer">GitHub</a></li>
                             <li><a href="https://gitlab.com/" target="_blank" rel="noopener noreferrer">GitLab</a></li>
                             <li><a href="https://gitea.io/" target="_blank" rel="noopener noreferrer">Gitea</a></li>
                             <li><a href="https://www.agno.com/" target="_blank" rel="noopener noreferrer">Agno</a></li>
+                            <li><a href="https://langflow.org/" target="_blank" rel="noopener noreferrer">Langflow</a></li>
+                            <li><a href="https://crewai.com/" target="_blank" rel="noopener noreferrer">CrewAI</a></li>
+                            <li><a href="https://microsoft.github.io/autogen/" target="_blank" rel="noopener noreferrer">AutoGen</a></li>
                             <li><a href="https://pandoc.org/" target="_blank" rel="noopener noreferrer">Pandoc</a></li>
                         </ul>
                     </div>
@@ -403,8 +408,20 @@
                         </ul>
                     </div>
                     <div class="service-category">
+                        <h3>Design, UI &amp; Creative</h3>
+                        <ul>
+                            <li><a href="https://github.com/nexu-io/open-design" target="_blank" rel="noopener noreferrer">Open Design</a></li>
+                            <li><a href="https://remotion.dev/" target="_blank" rel="noopener noreferrer">Remotion</a></li>
+                            <li><a href="https://animejs.com/" target="_blank" rel="noopener noreferrer">Anime.js</a></li>
+                            <li><a href="https://muapi.ai/" target="_blank" rel="noopener noreferrer">MuAPI</a></li>
+                            <li><a href="https://github.com/snubroot/Veo-3-Meta-Framework" target="_blank" rel="noopener noreferrer">Video Prompt Design</a></li>
+                            <li><a href="https://github.com/yt-dlp/yt-dlp" target="_blank" rel="noopener noreferrer">yt-dlp</a></li>
+                        </ul>
+                    </div>
+                    <div class="service-category">
                         <h3>Security &amp; Quality</h3>
                         <ul>
+                            <li><a href="https://github.com/gopasspw/gopass" target="_blank" rel="noopener noreferrer">gopass</a></li>
                             <li><a href="https://github.com/dani-garcia/vaultwarden" target="_blank" rel="noopener noreferrer">Vaultwarden</a></li>
                             <li><a href="https://sonarcloud.io/" target="_blank" rel="noopener noreferrer">SonarCloud</a></li>
                             <li><a href="https://www.codefactor.io/" target="_blank" rel="noopener noreferrer">CodeFactor</a></li>
@@ -412,6 +429,10 @@
                             <li><a href="https://coderabbit.ai/" target="_blank" rel="noopener noreferrer">CodeRabbit</a></li>
                             <li><a href="https://qlty.sh/" target="_blank" rel="noopener noreferrer">Qlty</a></li>
                             <li><a href="https://snyk.io/" target="_blank" rel="noopener noreferrer">Snyk</a></li>
+                            <li><a href="https://socket.dev/" target="_blank" rel="noopener noreferrer">Socket</a></li>
+                            <li><a href="https://sentry.io/" target="_blank" rel="noopener noreferrer">Sentry</a></li>
+                            <li><a href="https://github.com/secretlint/secretlint" target="_blank" rel="noopener noreferrer">Secretlint</a></li>
+                            <li><a href="https://google.github.io/osv-scanner/" target="_blank" rel="noopener noreferrer">OSV Scanner</a></li>
                             <li><a href="https://cloud.google.com/gemini/docs/codeassist/overview" target="_blank" rel="noopener noreferrer">Gemini Code Assist</a></li>
                         </ul>
                     </div>
@@ -422,6 +443,17 @@
                             <li><a href="https://repomix.com/" target="_blank" rel="noopener noreferrer">Repomix</a></li>
                             <li><a href="https://context7.io/" target="_blank" rel="noopener noreferrer">Context7</a></li>
                             <li><a href="https://dspy.ai/" target="_blank" rel="noopener noreferrer">DSPy</a></li>
+                            <li><a href="https://dspyground.com/" target="_blank" rel="noopener noreferrer">DSPyGround</a></li>
+                            <li><a href="https://github.com/ggml-org/llama.cpp" target="_blank" rel="noopener noreferrer">Local Models</a></li>
+                        </ul>
+                    </div>
+                    <div class="service-category">
+                        <h3>Documents &amp; OCR</h3>
+                        <ul>
+                            <li><a href="https://libpdf.dev/" target="_blank" rel="noopener noreferrer">LibPDF</a></li>
+                            <li><a href="https://github.com/opendatalab/MinerU" target="_blank" rel="noopener noreferrer">MinerU</a></li>
+                            <li><a href="https://github.com/Zipstack/unstract" target="_blank" rel="noopener noreferrer">Unstract</a></li>
+                            <li><a href="https://ollama.com/library/glm-ocr" target="_blank" rel="noopener noreferrer">GLM-OCR</a></li>
                         </ul>
                     </div>
                     <div class="service-category">
@@ -429,6 +461,7 @@
                         <ul>
                             <li><a href="https://pagespeed.web.dev/" target="_blank" rel="noopener noreferrer">PageSpeed Insights</a></li>
                             <li><a href="https://developer.chrome.com/docs/lighthouse/" target="_blank" rel="noopener noreferrer">Lighthouse</a></li>
+                            <li><a href="https://www.webpagetest.org/" target="_blank" rel="noopener noreferrer">WebPageTest</a></li>
                             <li><a href="https://www.marcusquinn.com/link/updown" target="_blank" rel="noopener noreferrer">Updown.io</a></li>
                         </ul>
                     </div>
@@ -439,6 +472,19 @@
                             <li><a href="https://github.com/browserbase/stagehand" target="_blank" rel="noopener noreferrer">Stagehand</a></li>
                             <li><a href="https://github.com/unclecode/crawl4ai" target="_blank" rel="noopener noreferrer">Crawl4AI</a></li>
                             <li><a href="https://chromedevtools.github.io/devtools-protocol/" target="_blank" rel="noopener noreferrer">Chrome DevTools</a></li>
+                            <li><a href="https://mkcert.dev/" target="_blank" rel="noopener noreferrer">Localdev</a></li>
+                        </ul>
+                    </div>
+                    <div class="service-category">
+                        <h3>Communications &amp; Voice</h3>
+                        <ul>
+                            <li><a href="https://www.twilio.com/" target="_blank" rel="noopener noreferrer">Twilio</a></li>
+                            <li><a href="https://mytelfon.com/" target="_blank" rel="noopener noreferrer">Telfon</a></li>
+                            <li><a href="https://matrix.org/" target="_blank" rel="noopener noreferrer">Matrix</a></li>
+                            <li><a href="https://simplex.chat/" target="_blank" rel="noopener noreferrer">SimpleX Chat</a></li>
+                            <li><a href="https://github.com/42wim/matterbridge" target="_blank" rel="noopener noreferrer">Matterbridge</a></li>
+                            <li><a href="https://github.com/huggingface/speech-to-speech" target="_blank" rel="noopener noreferrer">Speech-to-Speech</a></li>
+                            <li><a href="https://github.com/pipecat-ai/pipecat" target="_blank" rel="noopener noreferrer">Pipecat</a></li>
                         </ul>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
         <section class="services" id="services">
             <div class="container">
                 <h2 class="section-title">AI DevOps Service Integrations</h2>
-                <p class="section-subtitle">aidevops connects your agents to the infrastructure, developer platforms, quality tools, document workflows, communications channels, creative systems, and local automation services that make delivery happen.</p>
+                <p class="section-subtitle">AIDevOps connects your agents to the infrastructure, developer platforms, quality tools, document workflows, communications channels, creative systems, and local automation services that make delivery happen.</p>
                 <div class="services-grid">
                     <div class="service-category">
                         <h3>Hosting</h3>
@@ -421,7 +421,7 @@
                     <div class="service-category">
                         <h3>Security &amp; Quality</h3>
                         <ul>
-                            <li><a href="https://github.com/gopasspw/gopass" target="_blank" rel="noopener noreferrer">gopass</a></li>
+                            <li><a href="https://github.com/gopasspw/gopass" target="_blank" rel="noopener noreferrer">Gopass</a></li>
                             <li><a href="https://github.com/dani-garcia/vaultwarden" target="_blank" rel="noopener noreferrer">Vaultwarden</a></li>
                             <li><a href="https://sonarcloud.io/" target="_blank" rel="noopener noreferrer">SonarCloud</a></li>
                             <li><a href="https://www.codefactor.io/" target="_blank" rel="noopener noreferrer">CodeFactor</a></li>
@@ -444,7 +444,7 @@
                             <li><a href="https://context7.io/" target="_blank" rel="noopener noreferrer">Context7</a></li>
                             <li><a href="https://dspy.ai/" target="_blank" rel="noopener noreferrer">DSPy</a></li>
                             <li><a href="https://dspyground.com/" target="_blank" rel="noopener noreferrer">DSPyGround</a></li>
-                            <li><a href="https://github.com/ggml-org/llama.cpp" target="_blank" rel="noopener noreferrer">Local Models</a></li>
+                            <li><a href="https://github.com/ggml-org/llama.cpp" target="_blank" rel="noopener noreferrer">Llama.cpp</a></li>
                         </ul>
                     </div>
                     <div class="service-category">
@@ -472,7 +472,7 @@
                             <li><a href="https://github.com/browserbase/stagehand" target="_blank" rel="noopener noreferrer">Stagehand</a></li>
                             <li><a href="https://github.com/unclecode/crawl4ai" target="_blank" rel="noopener noreferrer">Crawl4AI</a></li>
                             <li><a href="https://chromedevtools.github.io/devtools-protocol/" target="_blank" rel="noopener noreferrer">Chrome DevTools</a></li>
-                            <li><a href="https://mkcert.dev/" target="_blank" rel="noopener noreferrer">Localdev</a></li>
+                            <li><a href="https://mkcert.dev/" target="_blank" rel="noopener noreferrer">mkcert</a></li>
                         </ul>
                     </div>
                     <div class="service-category">


### PR DESCRIPTION
## Summary
- Expands the homepage service integrations section to better match current aidevops docs.
- Adds coverage for agent frameworks, design/creative tools, document/OCR workflows, security/quality services, performance tools, browser automation, communications, and voice AI.
- Adds a short intro line explaining how service integrations fit into aidevops delivery workflows.

## Verification
- python3 -m html.parser index.html
- JSON-LD parsed successfully with json.loads
- git diff --check origin/main...HEAD
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.59 with gpt-5.5 spent 1h 11m and 364,963 tokens on this with the user in an interactive session.