### PR TITLE
docs: mark affiliate links sponsored

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,11 +360,11 @@
                     <div class="service-category">
                         <h3>Hosting</h3>
                         <ul>
-                            <li><a href="https://www.marcusquinn.com/link/hostinger" target="_blank" rel="noopener noreferrer">Hostinger</a></li>
-                            <li><a href="https://www.marcusquinn.com/link/hetzner" target="_blank" rel="noopener noreferrer">Hetzner Cloud</a></li>
+                            <li><a href="https://www.marcusquinn.com/link/hostinger" target="_blank" rel="sponsored noopener noreferrer">Hostinger</a></li>
+                            <li><a href="https://www.marcusquinn.com/link/hetzner" target="_blank" rel="sponsored noopener noreferrer">Hetzner Cloud</a></li>
                             <li><a href="https://closte.com/" target="_blank" rel="noopener noreferrer">Closte</a></li>
                             <li><a href="https://coolify.io/" target="_blank" rel="noopener noreferrer">Coolify</a></li>
-                            <li><a href="https://www.marcusquinn.com/link/cloudron" target="_blank" rel="noopener noreferrer">Cloudron</a></li>
+                            <li><a href="https://www.marcusquinn.com/link/cloudron" target="_blank" rel="sponsored noopener noreferrer">Cloudron</a></li>
                             <li><a href="https://vercel.com/" target="_blank" rel="noopener noreferrer">Vercel</a></li>
                             <li><a href="https://aws.amazon.com/" target="_blank" rel="noopener noreferrer">AWS</a></li>
                             <li><a href="https://www.digitalocean.com/" target="_blank" rel="noopener noreferrer">DigitalOcean</a></li>
@@ -376,9 +376,9 @@
                         <ul>
                             <li><a href="https://www.cloudflare.com/" target="_blank" rel="noopener noreferrer">Cloudflare</a></li>
                             <li><a href="https://www.spaceship.com/" target="_blank" rel="noopener noreferrer">Spaceship</a></li>
-                            <li><a href="https://www.marcusquinn.com/link/101domain" target="_blank" rel="noopener noreferrer">101domains</a></li>
+                            <li><a href="https://www.marcusquinn.com/link/101domain" target="_blank" rel="sponsored noopener noreferrer">101domains</a></li>
                             <li><a href="https://aws.amazon.com/route53/" target="_blank" rel="noopener noreferrer">AWS Route 53</a></li>
-                            <li><a href="https://www.marcusquinn.com/link/namecheap" target="_blank" rel="noopener noreferrer">Namecheap</a></li>
+                            <li><a href="https://www.marcusquinn.com/link/namecheap" target="_blank" rel="sponsored noopener noreferrer">Namecheap</a></li>
                         </ul>
                     </div>
                     <div class="service-category">
@@ -462,7 +462,7 @@
                             <li><a href="https://pagespeed.web.dev/" target="_blank" rel="noopener noreferrer">PageSpeed Insights</a></li>
                             <li><a href="https://developer.chrome.com/docs/lighthouse/" target="_blank" rel="noopener noreferrer">Lighthouse</a></li>
                             <li><a href="https://www.webpagetest.org/" target="_blank" rel="noopener noreferrer">WebPageTest</a></li>
-                            <li><a href="https://www.marcusquinn.com/link/updown" target="_blank" rel="noopener noreferrer">Updown.io</a></li>
+                            <li><a href="https://www.marcusquinn.com/link/updown" target="_blank" rel="sponsored noopener noreferrer">Updown.io</a></li>
                         </ul>
                     </div>
                     <div class="service-category">


### PR DESCRIPTION
## Summary
- Adds `sponsored` to `rel` attributes for `marcusquinn.com/link/...` affiliate links.
- Keeps `noopener noreferrer` on those external links.
- Leaves normal editorial external links followed.

## Verification
- python3 -m html.parser index.html
- JSON-LD parsed successfully with json.loads
- git diff --check
- Confirmed six affiliate links use `rel="sponsored noopener noreferrer"`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.59 with gpt-5.5 spent 5h 16m and 612,177 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sponsored service integration links to include proper sponsorship attribution, affecting Hostinger, Hetzner Cloud, Cloudron, 101domains, Namecheap, and Updown.io.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->