### PR TITLE
docs: use smart paragraph wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -50,10 +50,8 @@ body {
     overflow-x: hidden;
 }
 
-@supports (text-wrap: pretty) {
-    p {
-        text-wrap: pretty;
-    }
+p {
+    text-wrap: pretty;
 }
 
 /* Container */

--- a/styles.css
+++ b/styles.css
@@ -50,6 +50,12 @@ body {
     overflow-x: hidden;
 }
 
+@supports (text-wrap: pretty) {
+    p {
+        text-wrap: pretty;
+    }
+}
+
 /* Container */
 .container {
     max-width: 1100px;


### PR DESCRIPTION
## Summary

- Add `text-wrap: pretty` for paragraph text when the browser supports it.
- Keep the rule progressive-enhancement only via `@supports`.

## Verification

- `python3 -m html.parser index.html`
- `python3 -m html.parser docs.html`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
