### PR TITLE
fix: align docs social metadata

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- Primary Meta Tags -->
-    <title>AIDevOps Documentation - AI DevOps Framework Setup &amp; Configuration Guide</title>
-    <meta name="title" content="AIDevOps Documentation - AI DevOps Framework Setup & Configuration Guide">
-    <meta name="description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials for the AI DevOps framework.">
+    <title>AIDevOps Documentation - AI DevOps Assistant Setup &amp; Configuration Guide</title>
+    <meta name="title" content="AIDevOps Documentation - AI DevOps Assistant Setup &amp; Configuration Guide">
+    <meta name="description" content="Complete AIDevOps documentation: setup guide for the open-source AI DevOps assistant framework, OpenCode plugin, MCP servers, services, and automation.">
     <meta name="keywords" content="ai devops documentation, aidevops guide, ai devops setup, mcp server configuration, ai assistant devops, devops framework docs, ai infrastructure guide, aidevops tutorial">
     <meta name="author" content="Marcus Quinn">
     <meta name="robots" content="index, follow">
@@ -16,8 +16,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://aidevops.sh/docs.html">
-    <meta property="og:title" content="AIDevOps Documentation - Setup & Configuration Guide">
-    <meta property="og:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
+    <meta property="og:title" content="AIDevOps Documentation - AI DevOps Assistant Setup &amp; Configuration Guide">
+    <meta property="og:description" content="Complete AIDevOps documentation: setup guide for the open-source AI DevOps assistant framework, OpenCode plugin, MCP servers, services, and automation.">
     <meta property="og:image" content="https://aidevops.sh/og-image.png">
     <meta property="og:site_name" content="AI DevOps">
     <meta property="og:locale" content="en_US">
@@ -26,8 +26,8 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://aidevops.sh/docs.html">
-    <meta name="twitter:title" content="AIDevOps Documentation - Setup & Configuration Guide">
-    <meta name="twitter:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
+    <meta name="twitter:title" content="AIDevOps Documentation - AI DevOps Assistant Setup &amp; Configuration Guide">
+    <meta name="twitter:description" content="Complete AIDevOps documentation: setup guide for the open-source AI DevOps assistant framework, OpenCode plugin, MCP servers, services, and automation.">
     <meta name="twitter:image" content="https://aidevops.sh/og-image.png">
     <meta name="twitter:creator" content="@marcuswquinn">
     


### PR DESCRIPTION
## Summary
- Align docs.html primary metadata with AI DevOps Assistant positioning
- Update Open Graph and Twitter titles/descriptions to match the primary metadata

## Testing
- git diff --check

Resolves #84

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.75 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation metadata to consistently reflect "AI DevOps Assistant" terminology across SEO, OpenGraph, and Twitter preview descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->