### PR TITLE
fix: document paragraph wrapping fallback

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -51,6 +51,7 @@ body {
 }
 
 p {
+    /* Unsupported browsers ignore this declaration, so no @supports wrapper is needed. */
     text-wrap: pretty;
 }
 


### PR DESCRIPTION
## Summary
- Confirms `styles.css` uses `text-wrap: pretty` directly with no `@supports` wrapper.
- Adds an inline note documenting that unsupported browsers ignore the declaration, preserving the progressive-enhancement behavior requested by the PR #81 review feedback.

Resolves #85

## Testing
- `test "$(rg -n '@supports\\s*\\([^)]*text-wrap' styles.css | wc -l | tr -d ' ')" = "0" && rg -n 'text-wrap:\\s*pretty' styles.css && git status --short --branch`
- Pre-commit validation passed during commit.

MERGE_SUMMARY
- Confirmed the review feedback from PR #81 is satisfied in `styles.css`.
- Documented the direct `text-wrap: pretty` declaration so the redundant `@supports` wrapper is not reintroduced.
- Verification: direct `text-wrap: pretty` match at `styles.css:55`; zero `@supports` text-wrap wrappers; pre-commit validation passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.75 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
