### PR TITLE
GH#90: docs: normalize docs social meta titles

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -16,7 +16,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://aidevops.sh/docs.html">
-    <meta property="og:title" content="AIDevOps Documentation - Setup & Configuration Guide">
+    <meta property="og:title" content="AIDevOps Documentation - AI DevOps Framework Setup & Configuration Guide">
     <meta property="og:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
     <meta property="og:image" content="https://aidevops.sh/og-image.png">
     <meta property="og:site_name" content="AI DevOps">
@@ -26,7 +26,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://aidevops.sh/docs.html">
-    <meta name="twitter:title" content="AIDevOps Documentation - Setup & Configuration Guide">
+    <meta name="twitter:title" content="AIDevOps Documentation - AI DevOps Framework Setup & Configuration Guide">
     <meta name="twitter:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
     <meta name="twitter:image" content="https://aidevops.sh/og-image.png">
     <meta name="twitter:creator" content="@marcuswquinn">


### PR DESCRIPTION
## Summary

Aligned the Open Graph and Twitter title metadata with the primary docs title while keeping literal ampersands in content attributes.

## Files Changed

docs.html

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** python3 inline metadata assertion verified the primary, Open Graph, and Twitter title content attributes and confirmed no &amp; entity appears inside any content attribute.

Resolves #90


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.85 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 3m and 35,606 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated social metadata to display the complete documentation title when the page is shared on social platforms. This improves the appearance of shared links and provides better context for viewers of the shared content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->