### PR TITLE
fix: normalize docs social titles

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -16,7 +16,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://aidevops.sh/docs.html">
-    <meta property="og:title" content="AIDevOps Documentation - Setup & Configuration Guide">
+    <meta property="og:title" content="AIDevOps Framework Setup & Configuration Guide">
     <meta property="og:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
     <meta property="og:image" content="https://aidevops.sh/og-image.png">
     <meta property="og:site_name" content="AI DevOps">
@@ -26,7 +26,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://aidevops.sh/docs.html">
-    <meta name="twitter:title" content="AIDevOps Documentation - Setup & Configuration Guide">
+    <meta name="twitter:title" content="AIDevOps Framework Setup & Configuration Guide">
     <meta name="twitter:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
     <meta name="twitter:image" content="https://aidevops.sh/og-image.png">
     <meta name="twitter:creator" content="@marcuswquinn">


### PR DESCRIPTION
## Summary
- Updated `docs.html` Open Graph and Twitter titles to the shorter 46-character title from issue #92.
- Preserved the Setup & Configuration Guide context while removing the truncation-prone Documentation prefix.

## Testing
- `python3` metadata validation: expected title length 46; exactly one matching `og:title`; exactly one matching `twitter:title`.
- Pre-commit hook passed for the final commit.

Resolves #92

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.90 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 2m and 36,886 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated page metadata to enhance visibility in search results and social media previews. Documentation titles now better reflect the AIDevOps Framework branding for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->