### PR TITLE
fix: escape docs social title ampersands (#94)

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -16,7 +16,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://aidevops.sh/docs.html">
-    <meta property="og:title" content="AIDevOps Documentation - Setup & Configuration Guide">
+    <meta property="og:title" content="AIDevOps Documentation - Setup &amp; Configuration Guide">
     <meta property="og:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
     <meta property="og:image" content="https://aidevops.sh/og-image.png">
     <meta property="og:site_name" content="AI DevOps">
@@ -26,7 +26,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:url" content="https://aidevops.sh/docs.html">
-    <meta name="twitter:title" content="AIDevOps Documentation - Setup & Configuration Guide">
+    <meta name="twitter:title" content="AIDevOps Documentation - Setup &amp; Configuration Guide">
     <meta name="twitter:description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials.">
     <meta name="twitter:image" content="https://aidevops.sh/og-image.png">
     <meta name="twitter:creator" content="@marcuswquinn">


### PR DESCRIPTION
## Summary
- Escapes ampersands in the Open Graph and Twitter title `content` attributes in `docs.html`.
- Resolves the review-followup finding from PR #93.

## Testing
- `python3` inline assertion check verifying both social title attributes use `&amp;` and no unescaped social title ampersands remain.

Resolves #94
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.94 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 26,246 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated social sharing metadata to display accurate titles when the documentation is shared on social media platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->