### PR TITLE
fix: escape docs primary title ampersand

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -6,7 +6,7 @@
     
     <!-- Primary Meta Tags -->
     <title>AIDevOps Documentation - AI DevOps Framework Setup &amp; Configuration Guide</title>
-    <meta name="title" content="AIDevOps Documentation - AI DevOps Framework Setup & Configuration Guide">
+    <meta name="title" content="AIDevOps Documentation - AI DevOps Framework Setup &amp; Configuration Guide">
     <meta name="description" content="Complete AIDevOps documentation: setup guide, MCP server configuration, service integrations, AI assistant compatibility, and DevOps automation tutorials for the AI DevOps framework.">
     <meta name="keywords" content="ai devops documentation, aidevops guide, ai devops setup, mcp server configuration, ai assistant devops, devops framework docs, ai infrastructure guide, aidevops tutorial">
     <meta name="author" content="Marcus Quinn">


### PR DESCRIPTION
## Summary
- Escaped the ampersand in the docs.html primary title meta tag.
- Matches the existing escaped title/social metadata pattern.

## Testing
- python3 inline check verified the escaped primary title meta tag is present and the unescaped variant is absent.

Resolves #98

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.96 plugin for [OpenCode](https://opencode.ai) v1.17.8 with gpt-5.5 spent 3m and 48,677 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a title metadata tag to the documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->