### PR TITLE
fix: improve light theme badge contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -879,8 +879,9 @@ pre,
     border-radius: 50%;
 }
 
-[data-theme="light"] .step-number {
-    color: #ffffff;
+[data-theme="light"] .step-number,
+[data-theme="light"] .btn-secondary .btn-badge {
+    color: var(--accent-on-fill);
 }
 
 .quickstart-step p {


### PR DESCRIPTION
## Summary
- Added an explicit light-theme color override for .step-number and .btn-secondary .btn-badge.
- Keeps both elements on var(--accent-on-fill) against var(--accent), matching the light theme token contract.

## Testing
- python3 inline verification confirmed the selector override exists in styles.css.
- Calculated white on #0d6f84 contrast ratio as 5.79:1, above WCAG AA 4.5:1.

Resolves #101
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.32 plugin for [OpenCode](https://opencode.ai) v1.17.13
