### PR TITLE
fix: improve file browser light mode contrast

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1326,6 +1326,12 @@ pre,
     position: relative;
 }
 
+[data-theme="light"] .agents-explorer {
+    background: linear-gradient(135deg, rgba(13, 111, 132, 0.08), transparent 42%), var(--surface);
+    border-color: var(--border);
+    box-shadow: inset 0 0 0 1px rgba(13, 111, 132, 0.04), 0 24px 50px -32px rgba(7, 16, 19, 0.28);
+}
+
 .agents-tree-pane {
     border-right: 1px solid var(--border);
     display: flex;
@@ -1355,6 +1361,11 @@ pre,
     padding: 0.7rem 0.8rem;
 }
 
+[data-theme="light"] .agents-search {
+    background: var(--bg-tertiary);
+    box-shadow: 0 1px 2px rgba(7, 16, 19, 0.08);
+}
+
 .agents-tree {
     display: flex;
     flex: 1;
@@ -1377,11 +1388,22 @@ pre,
     white-space: nowrap;
 }
 
+[data-theme="light"] .agents-tree-item {
+    background: rgba(13, 111, 132, 0.07);
+    color: var(--text-secondary);
+}
+
 .agents-tree-item:hover,
 .agents-tree-item.active {
     background: var(--accent-subtle);
     border-color: var(--border);
     color: var(--accent);
+}
+
+[data-theme="light"] .agents-tree-item:hover,
+[data-theme="light"] .agents-tree-item.active {
+    background: rgba(13, 111, 132, 0.13);
+    color: var(--accent-strong);
 }
 
 .agents-tree-item.folder {
@@ -1394,6 +1416,10 @@ pre,
 
 .agents-tree-item.current {
     color: var(--accent);
+}
+
+[data-theme="light"] .agents-tree-item.current {
+    color: var(--accent-strong);
 }
 
 .agents-tree-item.parent {
@@ -1430,6 +1456,10 @@ pre,
     white-space: nowrap;
 }
 
+[data-theme="light"] .agents-content-header span {
+    color: var(--accent-strong);
+}
+
 .agents-content-header a {
     color: var(--text-muted);
     flex: 0 0 auto;
@@ -1454,6 +1484,10 @@ pre,
     white-space: pre-wrap;
 }
 
+[data-theme="light"] .agents-content {
+    color: var(--text-secondary);
+}
+
 .syntax-comment {
     color: #7a8590;
 }
@@ -1474,6 +1508,11 @@ pre,
 .syntax-list,
 .syntax-fence {
     color: var(--accent);
+}
+
+[data-theme="light"] .syntax-list,
+[data-theme="light"] .syntax-fence {
+    color: var(--accent-strong);
 }
 
 [data-theme="light"] .syntax-comment {


### PR DESCRIPTION
## Summary
- Switches the .agents file browser panel to a light-mode surface instead of the dark code background.
- Adds light-mode contrast overrides for the search field, tree rows, active/current states, path header, and syntax list/fence tokens.

## Verification
- python3 selector verification for index.html/styles.css
- python3 -m py_compile scripts/update_site_stats.py
- python3 -m http.server 8765 with HTTP 200 checks for /, /styles.css, /script.js
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved light theme appearance for the Agents Explorer UI.
  * Updated panel, search, tree item, content header, and content text colors to better match light-mode styling.
  * Refined syntax highlighting colors in light theme for improved readability and contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->