### PR TITLE
fix: balance supported tools wrap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -595,7 +595,7 @@ pre,
     gap: 0.55rem 0.9rem;
     font-size: 0.9rem;
     list-style: none;
-    max-width: 780px;
+    max-width: 600px;
     margin: 0 auto;
     padding: 0;
 }


### PR DESCRIPTION
## Summary
- Narrow the supported tools list content area from 780px to 600px so desktop wrapping breaks after Claude Code.

## Verification
- Static check confirmed supported tools markup/order and `max-width: 600px` are present.
- `python3 -m py_compile scripts/update_site_stats.py`
- Pre-commit quality validation passed during commit.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13
