### PR TITLE
feat: move stats badges above graphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,6 +336,15 @@
                     <p class="section-subtitle">AIDevOps is the exact same systems we use and evolve every day to build and optimise websites, apps, marketing, businessses, and client services.</p>
                 </div>
 
+                <div class="capability-strip" aria-label="Aidevops framework capability metrics">
+                    <div class="capability-pill"><strong>12</strong><span>primary agents</span></div>
+                    <div class="capability-pill"><strong>2,200+</strong><span>agent docs</span></div>
+                    <div class="capability-pill"><strong>1,800+</strong><span>helper scripts</span></div>
+                    <div class="capability-pill"><strong>185+</strong><span>commands &amp; workflows</span></div>
+                    <div class="capability-pill"><strong>30+</strong><span>services</span></div>
+                    <div class="capability-pill"><strong>20</strong><span>MCP servers</span></div>
+                </div>
+
                 <div class="stats-grid" aria-live="polite">
                     <article class="stat-card stat-card-wide monthly-card">
                         <div class="stat-card-header">
@@ -368,15 +377,6 @@
                         </div>
                         <svg class="commit-chart" id="commitChart" viewBox="0 0 900 260" role="img" aria-label="Commits per day over the repository lifetime"></svg>
                     </article>
-                </div>
-
-                <div class="capability-strip" aria-label="Aidevops framework capability metrics">
-                    <div class="capability-pill"><strong>12</strong><span>primary agents</span></div>
-                    <div class="capability-pill"><strong>2,200+</strong><span>agent docs</span></div>
-                    <div class="capability-pill"><strong>1,800+</strong><span>helper scripts</span></div>
-                    <div class="capability-pill"><strong>185+</strong><span>commands &amp; workflows</span></div>
-                    <div class="capability-pill"><strong>30+</strong><span>services</span></div>
-                    <div class="capability-pill"><strong>20</strong><span>MCP servers</span></div>
                 </div>
 
                 <div class="depth-grid depth-grid-single">

--- a/styles.css
+++ b/styles.css
@@ -1251,7 +1251,7 @@ pre,
     display: grid;
     gap: 0.75rem;
     grid-template-columns: repeat(6, minmax(0, 1fr));
-    margin: 1.5rem auto;
+    margin: 0 auto 1.5rem;
     max-width: 1000px;
 }
 


### PR DESCRIPTION
## Summary
- Moves the capability metric badge strip above the stats graph cards on the homepage.
- Tightens the strip margin so it sits directly between the stats intro and graph panels.

## Verification
- `python3 - <<'PY' ...` layout order check passed
- `python3 -m py_compile scripts/update_site_stats.py`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 with gpt-5.5 spent 4m and 70,914 tokens on this with the user in an interactive session.