### PR TITLE
fix: restore stats panel spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1280,6 +1280,7 @@ pre,
 
 .depth-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    margin-top: 1.5rem;
 }
 
 .depth-grid-single {


### PR DESCRIPTION
## Summary
- Restores vertical spacing between the stats graph stack and the efficiency signals panel.
- Keeps the graph and depth panels aligned to the existing 1000px stats layout.

## Verification
- `python3 - <<'PY' ...` spacing rule check passed
- `python3 -m py_compile scripts/update_site_stats.py`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 with gpt-5.5 spent 17m and 205,634 tokens on this with the user in an interactive session.