### PR TITLE
fix: bust homepage css cache

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css?v=9">
+    <link rel="stylesheet" href="styles.css?v=10">
     
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2">


### PR DESCRIPTION
## Summary
- Bumps the homepage stylesheet cache key so the deployed spacing fix is served immediately.

## Verification
- `python3 - <<'PY' ...` cache-busted spacing check passed
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 with gpt-5.5 spent 22m and 238,738 tokens on this with the user in an interactive session.