### PR TITLE
fix: show file browser links on hover

### DIFF
--- a/script.js
+++ b/script.js
@@ -660,19 +660,23 @@
         const children = childItems(path);
         const rows = [`<span class="agents-directory-title">${escapeHtml(displayPath(path))}</span>`];
         if (path !== '.agents') {
-            rows.push(`<button class="agents-content-item parent" type="button" data-path="${escapeHtml(parentPath(path))}">↰ ../</button>`);
+            const parent = parentPath(path);
+            rows.push(`<a class="agents-content-item parent" href="${githubLinkForPath(parent, 'tree')}" data-path="${escapeHtml(parent)}">↰ ../</a>`);
         }
         children.slice(0, 240).forEach((child) => {
             const icon = child.type === 'tree' ? '▸' : '•';
             const name = `${child.path.split('/').pop()}${child.type === 'tree' ? '/' : ''}`;
-            rows.push(`<button class="agents-content-item ${child.type === 'tree' ? 'folder' : 'file'}" type="button" data-path="${escapeHtml(child.path)}">${icon} ${escapeHtml(name)}</button>`);
+            rows.push(`<a class="agents-content-item ${child.type === 'tree' ? 'folder' : 'file'}" href="${githubLinkForPath(child.path, child.type)}" data-path="${escapeHtml(child.path)}">${icon} ${escapeHtml(name)}</a>`);
         });
         if (children.length > 240) rows.push(`<span class="agents-directory-more">… ${children.length - 240} more items</span>`);
         setDirectoryContent(path, rows.join(''), githubLinkForPath(path, 'tree'));
         const content = $('agentsContent');
         if (content) {
-            content.querySelectorAll('.agents-content-item').forEach((button) => {
-                button.addEventListener('click', () => selectTreeItem(button.dataset.path));
+            content.querySelectorAll('.agents-content-item').forEach((link) => {
+                link.addEventListener('click', (event) => {
+                    event.preventDefault();
+                    selectTreeItem(link.dataset.path);
+                });
             });
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -1523,13 +1523,19 @@ pre,
     font: inherit;
     padding: 0.08rem 0;
     text-align: left;
-    width: fit-content;
+    text-decoration: underline;
+    text-decoration-color: transparent;
+    text-decoration-thickness: 0.08em;
+    text-underline-offset: 0.18em;
+    transition: color 0.15s ease, text-decoration-color 0.15s ease;
+    width: max-content;
 }
 
 .agents-content-item:hover,
 .agents-content-item:focus-visible {
     color: var(--accent);
-    text-decoration: underline;
+    outline: none;
+    text-decoration-color: currentColor;
 }
 
 .agents-content-item.folder,
@@ -1537,8 +1543,19 @@ pre,
     color: var(--text-primary);
 }
 
+.agents-content-item.folder:hover,
+.agents-content-item.folder:focus-visible,
+.agents-content-item.parent:hover,
+.agents-content-item.parent:focus-visible {
+    color: var(--accent);
+}
+
 [data-theme="light"] .agents-content-item:hover,
-[data-theme="light"] .agents-content-item:focus-visible {
+[data-theme="light"] .agents-content-item:focus-visible,
+[data-theme="light"] .agents-content-item.folder:hover,
+[data-theme="light"] .agents-content-item.folder:focus-visible,
+[data-theme="light"] .agents-content-item.parent:hover,
+[data-theme="light"] .agents-content-item.parent:focus-visible {
     color: var(--accent-strong);
 }
 


### PR DESCRIPTION
## Summary
- Render right-pane directory rows as real anchors with GitHub href fallbacks while intercepting clicks for in-page drilldown.
- Add transparent underline affordance that becomes accent-coloured on hover/focus.
- Ensure folder and parent entries also turn accent-coloured on hover instead of staying primary text colour.

## Verification
- `node --check script.js`
- `git diff --check`

## Release
- User approved admin merge after checks pass.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 57m and 226,824 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory items and parent navigation now behave like real links, making it easier to open content directly and share the current location.
* **Style**
  * Improved hover and focus states in the directory pane for clearer visual feedback.
  * Updated underline behavior and link colors for a more polished, consistent look across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->