### PR TITLE
fix: remove duplicate file browser path

### DIFF
--- a/script.js
+++ b/script.js
@@ -658,7 +658,7 @@
 
     function renderDirectory(path) {
         const children = childItems(path);
-        const rows = [`<span class="agents-directory-title">${escapeHtml(displayPath(path))}</span>`];
+        const rows = [];
         if (path !== '.agents') {
             const parent = parentPath(path);
             rows.push(`<a class="agents-content-item parent" href="${githubLinkForPath(parent, 'tree')}" data-path="${escapeHtml(parent)}">↰ ../</a>`);

--- a/styles.css
+++ b/styles.css
@@ -1507,7 +1507,6 @@ pre,
     white-space: pre-wrap;
 }
 
-.agents-directory-title,
 .agents-directory-more {
     color: var(--text-muted);
     display: block;


### PR DESCRIPTION
## Summary
- Remove the duplicated directory path line from the .agents browser content pane.
- Keep the breadcrumb header as the single path/navigation indicator.
- Preserve parent/file/folder link navigation in the directory listing.

## Verification
- `node --check script.js`
- `git diff --check`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 1h 14m and 336,735 tokens on this with the user in an interactive session.