### PR TITLE
feat: add docs sidebar navigation

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -36,8 +36,16 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps Docs">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512'><path fill='%23B2E969' d='M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416H544c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32s14.3-32 32-32z'/></svg>">
+    <link rel="stylesheet" href="styles.css?v=11">
+    
+    <!-- Favicons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=3">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=3">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=3">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=3">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=3">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=3">
+    <link rel="manifest" href="/site.webmanifest?v=3">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -108,7 +116,32 @@
         </div>
     </nav>
 
-    <main class="docs-container">
+    <main class="docs-shell">
+        <aside class="docs-sidebar" aria-label="Documentation navigation">
+            <nav class="docs-sidebar-inner">
+                <div class="docs-sidebar-section">
+                    <p class="docs-sidebar-label">Pages</p>
+                    <a class="docs-sidebar-link active" href="docs.html">Documentation</a>
+                    <a class="docs-sidebar-link docs-sidebar-child active" href="docs.html" aria-current="page">README</a>
+                </div>
+                <div class="docs-sidebar-section docs-toc-section">
+                    <p class="docs-sidebar-label">On this page</p>
+                    <ol class="docs-toc" id="docsToc" aria-label="Table of contents"></ol>
+                </div>
+            </nav>
+        </aside>
+
+        <details class="docs-mobile-nav">
+            <summary>Documentation navigation</summary>
+            <div class="docs-mobile-nav-panel">
+                <a class="docs-sidebar-link active" href="docs.html">Documentation</a>
+                <a class="docs-sidebar-link docs-sidebar-child active" href="docs.html" aria-current="page">README</a>
+                <p class="docs-sidebar-label">On this page</p>
+                <ol class="docs-toc" id="docsMobileToc" aria-label="Mobile table of contents"></ol>
+            </div>
+        </details>
+
+        <div class="docs-container">
         <div class="docs-content">
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn --><h1>AI DevOps Framework</h1>
@@ -4441,6 +4474,7 @@ bash &lt;(curl -fsSL https://aidevops.sh/install)
             <div class="back-to-top">
                 <a href="#">Back to top</a>
             </div>
+        </div>
         </div>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -223,6 +223,63 @@
         heading.id = slug;
     });
 
+    const tocTargets = Array.from(document.querySelectorAll('.docs-content h2, .docs-content h3'));
+    const tocContainers = [
+        document.getElementById('docsToc'),
+        document.getElementById('docsMobileToc')
+    ].filter(Boolean);
+
+    function buildToc(container) {
+        if (!container || tocTargets.length === 0) return;
+        const fragment = document.createDocumentFragment();
+
+        tocTargets.forEach((heading) => {
+            const item = document.createElement('li');
+            const link = document.createElement('a');
+            link.href = `#${heading.id}`;
+            link.textContent = heading.textContent.replace(/\s+/g, ' ').trim();
+            link.className = `docs-toc-link depth-${heading.tagName.slice(1)}`;
+            link.dataset.tocTarget = heading.id;
+            item.appendChild(link);
+            fragment.appendChild(item);
+        });
+
+        container.replaceChildren(fragment);
+    }
+
+    tocContainers.forEach(buildToc);
+
+    function setActiveTocLink(id) {
+        if (!id) return;
+        document.querySelectorAll('.docs-toc-link.active').forEach((link) => {
+            link.classList.remove('active');
+            link.removeAttribute('aria-current');
+        });
+        document.querySelectorAll('.docs-toc-link').forEach((link) => {
+            if (link.dataset.tocTarget === id) {
+                link.classList.add('active');
+                link.setAttribute('aria-current', 'location');
+            }
+        });
+    }
+
+    if ('IntersectionObserver' in window && tocTargets.length > 0) {
+        const observer = new IntersectionObserver((entries) => {
+            const visible = entries
+                .filter((entry) => entry.isIntersecting)
+                .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+            if (visible[0]) {
+                setActiveTocLink(visible[0].target.id);
+            }
+        }, { rootMargin: '-20% 0px -70% 0px', threshold: 0.01 });
+
+        tocTargets.forEach((heading) => observer.observe(heading));
+    }
+
+    if (tocTargets[0]) {
+        setActiveTocLink(tocTargets[0].id);
+    }
+
     // Smooth scroll for anchor links, update URL hash
     document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
         anchor.addEventListener('click', (e) => {
@@ -238,6 +295,9 @@
                 e.preventDefault();
                 target.scrollIntoView({ behavior: 'smooth', block: 'start' });
                 history.replaceState(null, '', href);
+                setActiveTocLink(target.id);
+                const mobileNav = anchor.closest('.docs-mobile-nav');
+                if (mobileNav) mobileNav.open = false;
             }
         });
     });

--- a/styles.css
+++ b/styles.css
@@ -1793,10 +1793,112 @@ pre,
     padding-top: 5rem;
 }
 
-.docs-container {
-    max-width: 900px;
+.docs-shell {
+    display: grid;
+    grid-template-columns: minmax(14rem, 17rem) minmax(0, 900px);
+    gap: 2rem;
+    max-width: 1220px;
     margin: 0 auto;
     padding: 2rem 1.5rem 4rem;
+    align-items: start;
+}
+
+.docs-sidebar {
+    position: sticky;
+    top: 6rem;
+    max-height: calc(100vh - 7rem);
+    overflow: auto;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: linear-gradient(180deg, var(--surface-raised), var(--surface));
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.16);
+}
+
+.docs-sidebar-inner {
+    padding: 1rem;
+}
+
+.docs-sidebar-section + .docs-sidebar-section {
+    margin-top: 1.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+}
+
+.docs-sidebar-label {
+    margin-bottom: 0.5rem;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.docs-sidebar-link,
+.docs-toc-link {
+    display: block;
+    border-radius: 10px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+
+.docs-sidebar-link {
+    padding: 0.55rem 0.75rem;
+    border: 1px solid transparent;
+    font-size: 0.95rem;
+    font-weight: 650;
+}
+
+.docs-sidebar-child {
+    margin-top: 0.25rem;
+    margin-left: 0.75rem;
+    padding-left: 0.9rem;
+    border-left: 1px solid var(--border);
+    font-size: 0.88rem;
+    font-weight: 600;
+}
+
+.docs-sidebar-link.active,
+.docs-sidebar-link:hover {
+    border-color: var(--border-hover);
+    background: var(--accent-subtle);
+    color: var(--text-primary);
+}
+
+.docs-toc {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.docs-toc li {
+    margin: 0;
+}
+
+.docs-toc-link {
+    padding: 0.38rem 0.5rem;
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    line-height: 1.35;
+}
+
+.docs-toc-link:hover,
+.docs-toc-link.active {
+    background: var(--accent-subtle);
+    color: var(--text-primary);
+}
+
+.docs-toc-link.depth-3 {
+    padding-left: 1.25rem;
+    font-size: 0.8rem;
+}
+
+.docs-mobile-nav {
+    display: none;
+}
+
+.docs-container {
+    min-width: 0;
 }
 
 .docs-header {
@@ -1966,6 +2068,42 @@ pre,
 @media (max-width: 920px) {
     .capability-strip {
         grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .docs-shell {
+        display: block;
+        padding: 1rem 1rem 4rem;
+    }
+
+    .docs-sidebar {
+        display: none;
+    }
+
+    .docs-mobile-nav {
+        display: block;
+        position: sticky;
+        top: 4.75rem;
+        z-index: 90;
+        margin-bottom: 1.5rem;
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        background: var(--nav-bg);
+        backdrop-filter: blur(18px);
+    }
+
+    .docs-mobile-nav summary {
+        cursor: pointer;
+        padding: 0.85rem 1rem;
+        color: var(--text-primary);
+        font-weight: 700;
+        list-style-position: inside;
+    }
+
+    .docs-mobile-nav-panel {
+        max-height: min(65vh, 34rem);
+        overflow: auto;
+        padding: 0 1rem 1rem;
+        border-top: 1px solid var(--border);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a Fumadocs-inspired docs sidebar with Documentation > README navigation
- generate desktop and mobile table-of-contents links from the README headings
- align docs.html favicon links with the home page favicon set

## Verification
- node --check script.js
- python3 HTMLParser parse for index.html and docs.html
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13
