### PR TITLE
fix: restore docs sidebar layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,16 +6,16 @@
     <title>404 - Page Not Found | aidevops</title>
     <meta name="description" content="The page you're looking for doesn't exist. Return to aidevops.sh">
     <meta name="robots" content="noindex, nofollow">
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css?v=12">
     
     <!-- Favicons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=4">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=4">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=4">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=4">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=4">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=4">
+    <link rel="manifest" href="/site.webmanifest?v=4">
     <style>
         .error-page {
             min-height: 100vh;

--- a/docs.html
+++ b/docs.html
@@ -36,8 +36,16 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps Docs">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512'><path fill='%23B2E969' d='M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416H544c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32s14.3-32 32-32z'/></svg>">
+    <link rel="stylesheet" href="styles.css?v=12">
+    
+    <!-- Favicons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=4">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=4">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=4">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=4">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=4">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=4">
+    <link rel="manifest" href="/site.webmanifest?v=4">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -108,7 +116,32 @@
         </div>
     </nav>
 
-    <main class="docs-container">
+    <main class="docs-shell">
+        <aside class="docs-sidebar" aria-label="Documentation navigation">
+            <nav class="docs-sidebar-inner">
+                <div class="docs-sidebar-section">
+                    <p class="docs-sidebar-label">Pages</p>
+                    <a class="docs-sidebar-link active" href="docs.html">Documentation</a>
+                    <a class="docs-sidebar-link docs-sidebar-child active" href="docs.html" aria-current="page">README</a>
+                </div>
+                <div class="docs-sidebar-section docs-toc-section">
+                    <p class="docs-sidebar-label">On this page</p>
+                    <ol class="docs-toc" id="docsToc" aria-label="Table of contents"></ol>
+                </div>
+            </nav>
+        </aside>
+
+        <details class="docs-mobile-nav">
+            <summary>Documentation navigation</summary>
+            <div class="docs-mobile-nav-panel">
+                <a class="docs-sidebar-link active" href="docs.html">Documentation</a>
+                <a class="docs-sidebar-link docs-sidebar-child active" href="docs.html" aria-current="page">README</a>
+                <p class="docs-sidebar-label">On this page</p>
+                <ol class="docs-toc" id="docsMobileToc" aria-label="Mobile table of contents"></ol>
+            </div>
+        </details>
+
+        <div class="docs-container">
         <div class="docs-content">
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn --><h1>AI DevOps Framework</h1>
@@ -4442,6 +4475,7 @@ bash &lt;(curl -fsSL https://aidevops.sh/install)
                 <a href="#">Back to top</a>
             </div>
         </div>
+        </div>
     </main>
 
     <footer class="footer">
@@ -4451,6 +4485,6 @@ bash &lt;(curl -fsSL https://aidevops.sh/install)
         </div>
     </footer>
 
-    <script src="script.js"></script>
+    <script src="script.js?v=2"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -41,16 +41,16 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css?v=10">
+    <link rel="stylesheet" href="styles.css?v=12">
     
     <!-- Favicons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=3">
-    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=3">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=3">
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=3">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=3">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=3">
-    <link rel="manifest" href="/site.webmanifest?v=3">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=4">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=4">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=4">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=4">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=4">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=4">
+    <link rel="manifest" href="/site.webmanifest?v=4">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">

--- a/styles.css
+++ b/styles.css
@@ -1901,6 +1901,13 @@ pre,
     min-width: 0;
 }
 
+/* Fallback for generated docs that have not yet been wrapped in .docs-shell. */
+.docs-page > .docs-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+}
+
 .docs-header {
     margin-bottom: 3rem;
     padding-bottom: 2rem;


### PR DESCRIPTION
## Summary
- restore the docs page shell/sidebar markup after README sync reverted it
- replace the docs inline favicon with the shared site favicon set
- bump favicon/style/script query strings and add a CSS fallback for legacy docs markup

## Verification
- node --check script.js
- Python HTMLParser parse for index.html, docs.html, and 404.html
- marker checks for docs shell, TOC, favicon v4, stylesheet v12, and script v2
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.33 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the docs page layout with a sidebar and mobile navigation area for easier browsing.
* **Bug Fixes**
  * Improved page rendering for docs pages by adding a layout fallback when the full wrapper isn’t present.
  * Added cache-busting updates to styles, icons, and the site manifest to help ensure users receive the latest assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->