### PR TITLE
fix: make docs sidebar resilient

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,16 +6,16 @@
     <title>404 - Page Not Found | aidevops</title>
     <meta name="description" content="The page you're looking for doesn't exist. Return to aidevops.sh">
     <meta name="robots" content="noindex, nofollow">
-    <link rel="stylesheet" href="styles.css?v=12">
+    <link rel="stylesheet" href="styles.css?v=13">
     
     <!-- Favicons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=4">
-    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=4">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=4">
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=4">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=4">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=4">
-    <link rel="manifest" href="/site.webmanifest?v=4">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=5">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=5">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=5">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=5">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=5">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=5">
+    <link rel="manifest" href="/site.webmanifest?v=5">
     <style>
         .error-page {
             min-height: 100vh;
@@ -105,6 +105,6 @@
         </div>
     </main>
 
-    <script src="script.js"></script>
+    <script src="script.js?v=3"></script>
 </body>
 </html>

--- a/docs.html
+++ b/docs.html
@@ -36,8 +36,16 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps Docs">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512'><path fill='%23B2E969' d='M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416H544c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32s14.3-32 32-32z'/></svg>">
+    <link rel="stylesheet" href="styles.css?v=13">
+    
+    <!-- Favicons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=5">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=5">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=5">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=5">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=5">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=5">
+    <link rel="manifest" href="/site.webmanifest?v=5">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -4451,6 +4459,6 @@ bash &lt;(curl -fsSL https://aidevops.sh/install)
         </div>
     </footer>
 
-    <script src="script.js"></script>
+    <script src="script.js?v=3"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -41,16 +41,16 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css?v=12">
+    <link rel="stylesheet" href="styles.css?v=13">
     
     <!-- Favicons -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=4">
-    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=4">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=4">
-    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=4">
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=4">
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=4">
-    <link rel="manifest" href="/site.webmanifest?v=4">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=5">
+    <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg?v=5">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico?v=5">
+    <link rel="icon" type="image/png" sizes="48x48" href="/favicon-48x48.png?v=5">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=5">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=5">
+    <link rel="manifest" href="/site.webmanifest?v=5">
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
@@ -733,6 +733,6 @@ Loading the live GitHub tree...</pre>
         </div>
     </footer>
 
-    <script src="script.js?v=2"></script>
+    <script src="script.js?v=3"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -223,6 +223,87 @@
         heading.id = slug;
     });
 
+    function ensureDocsFavicons() {
+        if (!document.body.classList.contains('docs-page')) return;
+
+        const faviconLinks = [
+            { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png?v=5' },
+            { rel: 'icon', type: 'image/svg+xml', sizes: 'any', href: '/favicon.svg?v=5' },
+            { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico?v=5' },
+            { rel: 'icon', type: 'image/png', sizes: '48x48', href: '/favicon-48x48.png?v=5' },
+            { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32x32.png?v=5' },
+            { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png?v=5' },
+            { rel: 'manifest', href: '/site.webmanifest?v=5' }
+        ];
+
+        document.querySelectorAll('link[rel="icon"], link[rel="apple-touch-icon"], link[rel="manifest"]').forEach((link) => {
+            link.remove();
+        });
+
+        faviconLinks.forEach((config) => {
+            const link = document.createElement('link');
+            Object.entries(config).forEach(([key, value]) => link.setAttribute(key, value));
+            document.head.appendChild(link);
+        });
+    }
+
+    function createDocsSidebar() {
+        const sidebar = document.createElement('aside');
+        sidebar.className = 'docs-sidebar';
+        sidebar.setAttribute('aria-label', 'Documentation navigation');
+        sidebar.innerHTML = `
+            <nav class="docs-sidebar-inner">
+                <div class="docs-sidebar-section">
+                    <p class="docs-sidebar-label">Pages</p>
+                    <a class="docs-sidebar-link active" href="docs.html">Documentation</a>
+                    <a class="docs-sidebar-link docs-sidebar-child active" href="docs.html" aria-current="page">README</a>
+                </div>
+                <div class="docs-sidebar-section docs-toc-section">
+                    <p class="docs-sidebar-label">On this page</p>
+                    <ol class="docs-toc" id="docsToc" aria-label="Table of contents"></ol>
+                </div>
+            </nav>`;
+        return sidebar;
+    }
+
+    function createDocsMobileNav() {
+        const mobileNav = document.createElement('details');
+        mobileNav.className = 'docs-mobile-nav';
+        mobileNav.innerHTML = `
+            <summary>Documentation navigation</summary>
+            <div class="docs-mobile-nav-panel">
+                <a class="docs-sidebar-link active" href="docs.html">Documentation</a>
+                <a class="docs-sidebar-link docs-sidebar-child active" href="docs.html" aria-current="page">README</a>
+                <p class="docs-sidebar-label">On this page</p>
+                <ol class="docs-toc" id="docsMobileToc" aria-label="Mobile table of contents"></ol>
+            </div>`;
+        return mobileNav;
+    }
+
+    function ensureDocsShell() {
+        if (!document.body.classList.contains('docs-page')) return;
+        if (document.querySelector('.docs-shell')) return;
+
+        const legacyContainer = document.querySelector('main.docs-container');
+        if (!legacyContainer) return;
+
+        const shell = document.createElement('main');
+        shell.className = 'docs-shell';
+        legacyContainer.replaceWith(shell);
+        shell.appendChild(createDocsSidebar());
+        shell.appendChild(createDocsMobileNav());
+
+        const contentContainer = document.createElement('div');
+        contentContainer.className = 'docs-container';
+        while (legacyContainer.firstChild) {
+            contentContainer.appendChild(legacyContainer.firstChild);
+        }
+        shell.appendChild(contentContainer);
+    }
+
+    ensureDocsFavicons();
+    ensureDocsShell();
+
     const tocTargets = Array.from(document.querySelectorAll('.docs-content h2, .docs-content h3'));
     const tocContainers = [
         document.getElementById('docsToc'),


### PR DESCRIPTION
## Summary
- restores the docs favicon link set and cache-busts favicon/CSS/script assets
- makes script.js rebuild the docs sidebar and mobile docs navigator when regenerated docs.html loses the sidebar wrapper
- makes script.js normalize docs favicons back to the shared site favicon set if regenerated HTML reintroduces the old inline icon

## Verification
- node --check script.js
- Python HTMLParser parse for index.html, docs.html, and 404.html
- marker checks for favicon v5, stylesheet v13, script v3, and durable docs sidebar functions
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.42 plugin for [OpenCode](https://opencode.ai) v1.17.13
