### PR TITLE
fix: render docs metric badges from raw svg URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -105,6 +105,6 @@
         </div>
     </main>
 
-    <script src="script.js?v=3"></script>
+    <script src="script.js?v=4"></script>
 </body>
 </html>

--- a/docs.html
+++ b/docs.html
@@ -174,9 +174,9 @@
 <a href="#mcp-integrations"><img src="https://img.shields.io/badge/MCP%20Servers-20-orange.svg" alt="MCP Servers"></a>
 <a href="#comprehensive-service-coverage"><img src="https://img.shields.io/badge/API%20Integrations-30+-blue.svg" alt="API Integrations"></a></p>
 <!-- Repository Metrics -->
-<p><a href="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/repo-metrics.md"><img src="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/badges/loc.svg" alt="Lines of code"></a>
-<a href="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/repo-metrics.md"><img src="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/badges/dependencies.svg" alt="Dependencies"></a></p>
-<p><a href="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/repo-metrics.md"><img src="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/badges/languages.svg" alt="Languages by lines of code"></a></p>
+<p><a href="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/repo-metrics.md"><img src="https://raw.githubusercontent.com/marcusquinn/aidevops/main/docs/metrics/badges/loc.svg" alt="Lines of code"></a>
+<a href="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/repo-metrics.md"><img src="https://raw.githubusercontent.com/marcusquinn/aidevops/main/docs/metrics/badges/dependencies.svg" alt="Dependencies"></a></p>
+<p><a href="https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/repo-metrics.md"><img src="https://raw.githubusercontent.com/marcusquinn/aidevops/main/docs/metrics/badges/languages.svg" alt="Languages by lines of code"></a></p>
 <!-- AI-CONTEXT-START --><h2>Quick Reference</h2>
 <ul>
 <li><strong>Purpose</strong>: AI-assisted DevOps automation framework</li>
@@ -4459,6 +4459,6 @@ bash &lt;(curl -fsSL https://aidevops.sh/install)
         </div>
     </footer>
 
-    <script src="script.js?v=3"></script>
+    <script src="script.js?v=4"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -733,6 +733,6 @@ Loading the live GitHub tree...</pre>
         </div>
     </footer>
 
-    <script src="script.js?v=3"></script>
+    <script src="script.js?v=4"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -247,6 +247,17 @@
         });
     }
 
+    function ensureDocsMetricBadges() {
+        if (!document.body.classList.contains('docs-page')) return;
+
+        const githubBlobPrefix = 'https://github.com/marcusquinn/aidevops/blob/main/docs/metrics/badges/';
+        const rawGithubPrefix = 'https://raw.githubusercontent.com/marcusquinn/aidevops/main/docs/metrics/badges/';
+
+        document.querySelectorAll(`.docs-content img[src^="${githubBlobPrefix}"]`).forEach((image) => {
+            image.src = image.src.replace(githubBlobPrefix, rawGithubPrefix);
+        });
+    }
+
     function createDocsSidebar() {
         const sidebar = document.createElement('aside');
         sidebar.className = 'docs-sidebar';
@@ -302,6 +313,7 @@
     }
 
     ensureDocsFavicons();
+    ensureDocsMetricBadges();
     ensureDocsShell();
 
     const tocTargets = Array.from(document.querySelectorAll('.docs-content h2, .docs-content h3'));


### PR DESCRIPTION
## Summary
- Repoint generated docs metric badge image sources from GitHub blob pages to raw SVG URLs.
- Add a docs-page runtime normalizer in script.js so future README-generated docs with blob badge URLs are repaired client-side.
- Bump the script.js cache key to v4 across site pages.

## Verification
- pre-edit-check.sh "Fix broken docs metric badge images"
- prework-discovery-helper.sh --keywords "docs metric badge images raw github blob svg" --files "docs.html script.js scripts/update_site_stats.py .github/workflows/update-site-stats.yml"
- node --check script.js
- python3 HTMLParser feed for index.html, docs.html, and 404.html
- Fetched raw loc.svg, dependencies.svg, and languages.svg successfully

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.46 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 3h 53m and 1,258,736 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the documentation page so metric badges load reliably.
* **Bug Fixes**
  * Updated page script references across the site to use the latest version, helping avoid stale cached JavaScript.
  * Refined the docs header/footer layout without changing the displayed badge content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->