### PR TITLE
docs: clarify homepage section flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,7 +440,6 @@
                         <svg class="commit-chart" id="commitChart" viewBox="0 0 900 260" role="img" aria-label="Commits per day over the repository lifetime"></svg>
                     </article>
                 </div>
-
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -441,51 +441,6 @@
                     </article>
                 </div>
 
-                <div class="depth-grid depth-grid-single">
-                    <article class="stat-card depth-card">
-                        <h3>Token and time efficiency signals</h3>
-                        <ul class="efficiency-list">
-                            <li><strong>Helper-first automation:</strong> deterministic scripts collect facts, compress output, and reduce repeated AI reasoning.</li>
-                            <li><strong>TOON-ready context:</strong> documented 20-60% token reduction vs JSON/YAML for indexes and registries.</li>
-                            <li><strong>Worktree discipline:</strong> isolated branches, PRs, CI gates, and review loops keep autonomous work auditable.</li>
-                            <li><strong>Domain routing:</strong> specialist agents avoid one-size-fits-all prompts for SEO, ops, security, content, finance, and more.</li>
-                        </ul>
-                    </article>
-                </div>
-
-                <article class="stat-card agents-explorer-card">
-                    <div class="stat-card-header">
-                        <h3>.agents file browser</h3>
-                        <span class="stat-source" id="folderSource">loading</span>
-                    </div>
-                    <div class="agents-explorer" aria-label="Navigable .agents directory browser">
-                        <aside class="agents-tree-pane">
-                            <label class="agents-search-label" for="agentsSearch">Search .agents</label>
-                            <input class="agents-search" id="agentsSearch" type="search" placeholder="agents, scripts, workflows...">
-                            <div class="agents-tree" id="agentsTree" role="tree">
-                                <button class="agents-tree-item folder active" type="button" data-path=".agents">.agents/</button>
-                                <button class="agents-tree-item folder" type="button" data-path=".agents/scripts">▸ scripts/</button>
-                                <button class="agents-tree-item folder" type="button" data-path=".agents/workflows">▸ workflows/</button>
-                                <button class="agents-tree-item folder" type="button" data-path=".agents/reference">▸ reference/</button>
-                                <button class="agents-tree-item folder" type="button" data-path=".agents/tools">▸ tools/</button>
-                            </div>
-                        </aside>
-                        <div class="agents-content-pane">
-                            <div class="agents-content-header">
-                                <span id="agentsContentPath">.agents/</span>
-                                <a id="agentsContentLink" href="https://github.com/marcusquinn/aidevops/tree/main/.agents" target="_blank" rel="noopener noreferrer">Open on GitHub</a>
-                            </div>
-                            <pre class="agents-content" id="agentsContent">.agents/
-
-▸ scripts/     helper automation that saves repeated AI reasoning
-▸ workflows/   repeatable playbooks for delivery, git, reviews, and ops
-▸ reference/   deeper guidance loaded only when needed
-▸ tools/       service, browser, security, hosting, and platform docs
-
-Loading the live GitHub tree...</pre>
-                        </div>
-                    </div>
-                </article>
             </div>
         </section>
 
@@ -515,11 +470,60 @@ Loading the live GitHub tree...</pre>
                         <p>Infrastructure, hosting, DNS, SEO, marketing, reports, content, video, browser automation, business operations, and personal productivity routines.</p>
                     </div>
                 </div>
+
+                <div class="feature-support-stack" aria-label="Supporting AI DevOps feature evidence">
+                    <div class="depth-grid depth-grid-single">
+                        <article class="stat-card depth-card">
+                            <h3>Token and time efficiency signals</h3>
+                            <ul class="efficiency-list">
+                                <li><strong>Helper-first automation:</strong> deterministic scripts collect facts, compress output, and reduce repeated AI reasoning.</li>
+                                <li><strong>TOON-ready context:</strong> documented 20-60% token reduction vs JSON/YAML for indexes and registries.</li>
+                                <li><strong>Worktree discipline:</strong> isolated branches, PRs, CI gates, and review loops keep autonomous work auditable.</li>
+                                <li><strong>Domain routing:</strong> specialist agents avoid one-size-fits-all prompts for SEO, ops, security, content, finance, and more.</li>
+                            </ul>
+                        </article>
+                    </div>
+
+                    <article class="stat-card agents-explorer-card">
+                        <div class="stat-card-header">
+                            <h3>.agents file browser</h3>
+                            <span class="stat-source" id="folderSource">loading</span>
+                        </div>
+                        <div class="agents-explorer" aria-label="Navigable .agents directory browser">
+                            <aside class="agents-tree-pane">
+                                <label class="agents-search-label" for="agentsSearch">Search .agents</label>
+                                <input class="agents-search" id="agentsSearch" type="search" placeholder="agents, scripts, workflows...">
+                                <div class="agents-tree" id="agentsTree" role="tree">
+                                    <button class="agents-tree-item folder active" type="button" data-path=".agents">.agents/</button>
+                                    <button class="agents-tree-item folder" type="button" data-path=".agents/scripts">▸ scripts/</button>
+                                    <button class="agents-tree-item folder" type="button" data-path=".agents/workflows">▸ workflows/</button>
+                                    <button class="agents-tree-item folder" type="button" data-path=".agents/reference">▸ reference/</button>
+                                    <button class="agents-tree-item folder" type="button" data-path=".agents/tools">▸ tools/</button>
+                                </div>
+                            </aside>
+                            <div class="agents-content-pane">
+                                <div class="agents-content-header">
+                                    <span id="agentsContentPath">.agents/</span>
+                                    <a id="agentsContentLink" href="https://github.com/marcusquinn/aidevops/tree/main/.agents" target="_blank" rel="noopener noreferrer">Open on GitHub</a>
+                                </div>
+                                <pre class="agents-content" id="agentsContent">.agents/
+
+▸ scripts/     helper automation that saves repeated AI reasoning
+▸ workflows/   repeatable playbooks for delivery, git, reviews, and ops
+▸ reference/   deeper guidance loaded only when needed
+▸ tools/       service, browser, security, hosting, and platform docs
+
+Loading the live GitHub tree...</pre>
+                            </div>
+                        </div>
+                    </article>
+                </div>
             </div>
         </section>
 
         <section class="services" id="services">
             <div class="container">
+                <div class="section-divider" aria-hidden="true"></div>
                 <h2 class="section-title">AI DevOps Services &amp; Integrations</h2>
                 <p class="section-subtitle">AIDevOps connects your agents to the infrastructure, developer platforms, quality tools, document workflows, communications channels, creative systems, and local automation services that make delivery happen.</p>
                 <div class="services-grid">
@@ -659,6 +663,7 @@ Loading the live GitHub tree...</pre>
 
         <section class="faq" id="faq">
             <div class="container">
+                <div class="section-divider" aria-hidden="true"></div>
                 <h2 class="section-title">AI DevOps FAQ</h2>
                 <div class="faq-list">
                     <article class="faq-item">

--- a/styles.css
+++ b/styles.css
@@ -1618,7 +1618,9 @@ pre,
 /* Features Section */
 .features {
     padding: 6rem 1.5rem;
-    background: var(--bg-primary);
+    background:
+        radial-gradient(circle at 80% 12%, rgba(102, 217, 242, 0.08), transparent 24%),
+        var(--bg-primary);
 }
 
 .section-title {
@@ -1693,9 +1695,27 @@ pre,
     line-height: 1.5;
 }
 
+.feature-support-stack {
+    margin-top: 3rem;
+}
+
+.feature-support-stack .depth-grid {
+    margin-top: 0;
+}
+
+.section-divider {
+    background: linear-gradient(90deg, transparent, var(--border-hover), var(--accent), var(--border-hover), transparent);
+    height: 1px;
+    margin: 0 auto 4rem;
+    max-width: 960px;
+    opacity: 0.8;
+}
+
 /* Services Section */
 .services {
-    padding: 6rem 1.5rem;
+    padding: 0 1.5rem 6rem;
+    background:
+        linear-gradient(180deg, var(--bg-secondary) 0%, color-mix(in srgb, var(--bg-secondary) 82%, var(--bg-primary)) 100%);
 }
 
 .services-grid {
@@ -1746,8 +1766,10 @@ pre,
 
 /* FAQ Section */
 .faq {
-    padding: 6rem 1.5rem;
-    background: var(--bg-primary);
+    padding: 0 1.5rem 6rem;
+    background:
+        radial-gradient(circle at 18% 20%, var(--accent-glow), transparent 26%),
+        var(--bg-primary);
 }
 
 .faq-list {
@@ -2183,8 +2205,12 @@ pre,
         padding: 1rem;
     }
     
-    .features, .services, .stats-panel, .cta {
+    .features, .stats-panel, .cta {
         padding: 4rem 1rem;
+    }
+
+    .services, .faq {
+        padding: 0 1rem 4rem;
     }
     
     .features-grid, .services-grid, .stats-grid, .depth-grid {


### PR DESCRIPTION
## Summary
- Move Token and time efficiency signals plus the .agents file browser under the four AI DevOps Features & Capabilities cards.
- Add visible section dividers before Services & Integrations and FAQ.
- Differentiate nearby section backgrounds so stats, features, services, and FAQ have clearer visual separation.

## Verification
- `node --check script.js`
- `python3 -m json.tool data/aidevops-stats.json >/dev/null`
- `python3 -m json.tool site.webmanifest >/dev/null`
- `python3 -m html.parser index.html >/dev/null`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.46 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized the homepage so the token/time efficiency signals and .agents browser now appear within the features area.
  * Added clearer visual section dividers before the services and FAQ content.

* **Style**
  * Updated section spacing and backgrounds for a more polished look, including new gradient and accent-glow treatments.
  * Improved mobile padding behavior across key homepage sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->