### PR TITLE
docs: apply homepage section dividers

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,6 +370,7 @@
 
         <section class="quickstart" id="quickstart">
             <div class="container">
+                <div class="section-divider" aria-hidden="true"></div>
                 <h2 class="section-title">Get started in seconds...</h2>
                 <div class="quickstart-steps">
                     <div class="quickstart-step">
@@ -392,6 +393,7 @@
 
         <section class="stats-panel" id="stats">
             <div class="container">
+                <div class="section-divider" aria-hidden="true"></div>
                 <div class="stats-header">
                     <p class="stats-kicker">24/7 Development</p>
                     <h2 class="section-title">Scaleable teamwork you can trust</h2>
@@ -445,6 +447,7 @@
 
         <section class="features" id="features">
             <div class="container">
+                <div class="section-divider" aria-hidden="true"></div>
                 <h2 class="section-title">AI DevOps Features &amp; Capabilities</h2>
                 <p class="section-subtitle">AI DevOps (aka: aidevops, aiops, ai ops) is built for the gap between “the model can probably do this” and “the work is actually done, verified, safe, and worth the cost.” It gives AI assistants context, routing, security, git hygiene, collaboration, observability, memory, and follow-through.</p>
                 <div class="features-grid">
@@ -723,6 +726,7 @@ Loading the live GitHub tree...</pre>
 
         <section class="cta" id="install">
             <div class="container">
+                <div class="section-divider" aria-hidden="true"></div>
                 <h2>Get Started with AI DevOps Today</h2>
                 <!-- Cloned from #install-box-source by script.js to avoid duplication -->
                 <div id="install-box-clone"></div>

--- a/styles.css
+++ b/styles.css
@@ -849,9 +849,8 @@ pre,
 
 /* Quickstart Section */
 .quickstart {
-    padding: 5rem 1.5rem;
+    padding: 0 1.5rem 5rem;
     background: var(--bg-secondary);
-    border-top: 1px solid var(--border);
 }
 
 .quickstart .section-title {
@@ -943,12 +942,10 @@ pre,
 
 /* Stats Panel */
 .stats-panel {
-    padding: 6rem 1.5rem;
+    padding: 0 1.5rem 6rem;
     background:
         radial-gradient(circle at 20% 20%, var(--accent-glow), transparent 30%),
         linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-    border-top: 1px solid var(--border);
-    border-bottom: 1px solid var(--border);
 }
 
 .stats-header {
@@ -1617,7 +1614,7 @@ pre,
 
 /* Features Section */
 .features {
-    padding: 6rem 1.5rem;
+    padding: 0 1.5rem 6rem;
     background:
         radial-gradient(circle at 80% 12%, rgba(102, 217, 242, 0.08), transparent 24%),
         var(--bg-primary);
@@ -1819,7 +1816,7 @@ pre,
 
 /* CTA Section */
 .cta {
-    padding: 6rem 1.5rem;
+    padding: 0 1.5rem 6rem;
     background: var(--bg-secondary);
     text-align: center;
 }
@@ -2205,11 +2202,7 @@ pre,
         padding: 1rem;
     }
     
-    .features, .stats-panel, .cta {
-        padding: 4rem 1rem;
-    }
-
-    .services, .faq {
+    .quickstart, .stats-panel, .features, .services, .faq, .cta {
         padding: 0 1rem 4rem;
     }
     


### PR DESCRIPTION
## Summary
- Apply the new gradient section divider to every main homepage section boundary after the hero.
- Normalize section top padding so dividers sit consistently across Quickstart, Stats, Features, Services, FAQ, and CTA.
- Remove older plain section border rules now replaced by the divider style.

## Verification
- `node --check script.js`
- `python3 -m json.tool data/aidevops-stats.json >/dev/null`
- `python3 -m json.tool site.webmanifest >/dev/null`
- `python3 -m html.parser index.html >/dev/null`
- `git diff --check`
- `divider_count= 6`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.46 plugin for [OpenCode](https://opencode.ai) v1.17.13
