### PR TITLE
fix: match docs codeblock colours

### DIFF
--- a/script.js
+++ b/script.js
@@ -793,8 +793,8 @@
         if (anchor) anchor.href = link;
     }
 
-    function highlightContent(path, text) {
-        const isMarkdown = /\.(md|markdown)$/i.test(path);
+    function highlightCode(text, options = {}) {
+        const isMarkdown = Boolean(options.isMarkdown);
         const escapedLines = text.split('\n').map((line) => {
             const escaped = escapeHtml(line);
             if (isMarkdown && /^\s*#{1,6}\s/.test(line)) return `<span class="syntax-heading">${escaped}</span>`;
@@ -807,6 +807,12 @@
                 .replace(/\b(\d+(?:\.\d+)?)\b/g, '<span class="syntax-number">$1</span>');
         });
         return escapedLines.join('\n');
+    }
+
+    window.aidevopsHighlightCode = highlightCode;
+
+    function highlightContent(path, text) {
+        return highlightCode(text, { isMarkdown: /\.(md|markdown)$/i.test(path) });
     }
 
     function renderDirectory(path) {
@@ -976,6 +982,19 @@
     }
 
     initStatsPanel();
+})();
+
+// Documentation Code Blocks — reuse the .agents preview syntax palette
+(function() {
+    const highlighter = window.aidevopsHighlightCode;
+    if (typeof highlighter !== 'function') return;
+
+    document.querySelectorAll('.docs-content pre code').forEach((code) => {
+        const languageClass = Array.from(code.classList).find((className) => className.startsWith('language-')) || '';
+        const isMarkdown = /language-(markdown|md)/i.test(languageClass);
+        code.innerHTML = highlighter(code.textContent, { isMarkdown });
+        code.closest('pre')?.classList.add('docs-codeblock-coloured');
+    });
 })();
 
 // Add intersection observer for fade-in animations

--- a/styles.css
+++ b/styles.css
@@ -2063,7 +2063,7 @@ pre,
 .docs-content pre code {
     background: none;
     padding: 0;
-    color: var(--accent);
+    color: var(--text-secondary);
 }
 
 [data-theme="light"] .docs-content pre {
@@ -2072,7 +2072,7 @@ pre,
 }
 
 [data-theme="light"] .docs-content pre code {
-    color: var(--accent);
+    color: var(--text-secondary);
 }
 
 [data-theme="light"] .docs-content code {


### PR DESCRIPTION
## Summary
- Reuses the .agents preview syntax highlighter for documentation page code blocks.
- Keeps docs codeblock base text neutral so the shared syntax colours stand out in dark and light themes.

## Verification
- node --check script.js
- python3 -m py_compile scripts/update_site_stats.py
- git diff --check main..HEAD

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.47 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation code blocks now use the same shared syntax highlighting as the rest of the app.
  * Markdown snippets in docs are automatically detected and highlighted correctly.

* **Bug Fixes**
  * Improved consistency of code coloring in documentation sections across themes.
  * Documentation code blocks now receive a clearer highlighted state when processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->