### PR TITLE
fix: improve mobile responsive layout

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -127,6 +127,15 @@ magick favicon-16x16.png favicon-32x32.png favicon-48x48.png favicon.ico
 - Check the social graph at full size and social-preview size; the install command needs visible right padding.
 - Verify live deploys by comparing live asset hashes against committed bytes after GitHub Pages deployment.
 
+## Responsive layout rules
+
+- Mobile pages must avoid document-level horizontal scrolling; oversized components should wrap, stack, or scroll inside their own card.
+- Section gutters collapse to the section padding at tablet/mobile widths so cards keep enough internal space.
+- Stats card headings and source pills stack on mobile; source text may wrap instead of forcing card overflow.
+- Chart cards keep horizontal scroll contained within `.monthly-chart`; the whole page should remain width-safe at `320`, `360`, `390`, `414`, and `768` pixel viewports.
+- The `.agents` file browser stacks tree above content on mobile. Search paths, breadcrumbs, file names, and preview text wrap within the card rather than clipping behind the right edge.
+- Install commands, quickstart command snippets, service links, and other long strings should use wrapping/word-break rules that preserve tap targets and readability.
+
 ## Verification checklist
 
 Before merging visual changes, run:

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css?v=13">
+    <link rel="stylesheet" href="styles.css?v=14">
     
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=5">

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,13 @@ html {
     scroll-behavior: smooth;
 }
 
+img,
+svg,
+video,
+canvas {
+    max-width: 100%;
+}
+
 body {
     font-family: var(--font-sans);
     background-color: var(--bg-primary);
@@ -112,6 +119,7 @@ pre,
     max-width: 1100px;
     margin: 0 auto;
     padding: 0 1.5rem;
+    width: 100%;
 }
 
 /* Navigation */
@@ -243,7 +251,7 @@ pre,
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 800px;
+    width: min(800px, 150vw);
     height: 500px;
     background: radial-gradient(ellipse at center, var(--accent-glow) 0%, transparent 62%);
     filter: blur(80px);
@@ -263,9 +271,11 @@ pre,
 
 .hero-content {
     max-width: 800px;
+    min-width: 0;
     text-align: center;
     position: relative;
     z-index: 1;
+    width: 100%;
 }
 
 .hero-logo {
@@ -301,6 +311,7 @@ pre,
     border: 1px solid var(--border);
     overflow: hidden;
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.7), inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    width: 100%;
 }
 
 .install-header {
@@ -310,22 +321,29 @@ pre,
     background: var(--surface-raised);
     border-bottom: 1px solid var(--border);
     gap: 1rem;
+    min-width: 0;
 }
 
 .install-dots {
     display: flex;
+    flex: 0 0 auto;
     gap: 0.5rem;
 }
 
 .install-tabs {
     display: flex;
+    flex: 1 1 auto;
     gap: 0;
     margin-left: 0.5rem;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: thin;
 }
 
 .install-tab {
     background: transparent;
     border: none;
+    flex: 0 0 auto;
     padding: 0.35rem 0.75rem;
     font-family: inherit;
     font-size: 0.85rem;
@@ -362,6 +380,7 @@ pre,
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
     width: 100%;
     padding: 1.25rem 1.5rem;
     background: transparent;
@@ -379,6 +398,8 @@ pre,
 
 .command-text {
     display: inline;
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .command-dim {
@@ -390,6 +411,7 @@ pre,
 }
 
 .copy-status {
+    flex: 0 0 auto;
     display: flex;
     align-items: center;
     color: var(--text-muted);
@@ -969,6 +991,7 @@ pre,
     gap: 1.5rem;
     max-width: 1000px;
     margin: 0 auto;
+    min-width: 0;
 }
 
 .stats-grid {
@@ -981,6 +1004,8 @@ pre,
     border-radius: 18px;
     padding: 1.5rem;
     box-shadow: 0 25px 50px -24px rgba(0, 0, 0, 0.8), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    min-width: 0;
+    overflow-wrap: anywhere;
     transition: border-color 0.2s, transform 0.2s;
 }
 
@@ -1018,6 +1043,8 @@ pre,
     color: var(--text-muted);
     font-family: var(--font-mono);
     font-size: 0.72rem;
+    max-width: 100%;
+    overflow-wrap: anywhere;
     padding: 0.2rem 0.55rem;
     white-space: nowrap;
 }
@@ -1066,9 +1093,12 @@ pre,
     align-items: end;
     display: flex;
     gap: 0.85rem;
+    max-width: 100%;
     min-height: 260px;
+    overscroll-behavior-x: contain;
     overflow-x: auto;
     padding: 1rem 0.25rem 0.5rem;
+    scrollbar-width: thin;
 }
 
 .monthly-group {
@@ -1163,6 +1193,7 @@ pre,
     background: linear-gradient(180deg, rgba(102, 217, 242, 0.06), transparent);
     border: 1px solid var(--border);
     border-radius: 14px;
+    display: block;
     min-height: 260px;
     overflow: visible;
     width: 100%;
@@ -1256,6 +1287,7 @@ pre,
     background: var(--accent-subtle);
     border: 1px solid var(--border);
     border-radius: 16px;
+    min-width: 0;
     padding: 1rem;
     text-align: center;
 }
@@ -1273,6 +1305,7 @@ pre,
     display: block;
     font-size: 0.78rem;
     margin-top: 0.45rem;
+    overflow-wrap: anywhere;
 }
 
 .depth-grid {
@@ -1307,6 +1340,7 @@ pre,
 .agents-explorer-card {
     margin: 1.5rem auto 0;
     max-width: 1000px;
+    width: 100%;
 }
 
 .agents-explorer {
@@ -1356,7 +1390,9 @@ pre,
     color: var(--text-primary);
     font: inherit;
     margin-bottom: 0.8rem;
+    min-width: 0;
     padding: 0.7rem 0.8rem;
+    width: 100%;
 }
 
 [data-theme="light"] .agents-search {
@@ -1500,6 +1536,7 @@ pre,
     margin: 0;
     min-height: 0;
     overflow: auto;
+    overflow-wrap: anywhere;
     padding: 1rem;
     white-space: pre-wrap;
 }
@@ -1524,6 +1561,8 @@ pre,
     text-decoration-thickness: 0.08em;
     text-underline-offset: 0.18em;
     transition: color 0.15s ease, text-decoration-color 0.15s ease;
+    max-width: 100%;
+    overflow-wrap: anywhere;
     width: max-content;
 }
 
@@ -1656,6 +1695,8 @@ pre,
     background: var(--surface-raised);
     border: 1px solid var(--border);
     border-radius: 16px;
+    min-width: 0;
+    overflow-wrap: anywhere;
     padding: 2rem;
     transition: all 0.2s;
 }
@@ -1753,6 +1794,7 @@ pre,
 
 .service-category li a {
     color: var(--text-secondary);
+    overflow-wrap: anywhere;
     text-decoration: none;
     transition: color 0.2s;
 }
@@ -2185,16 +2227,57 @@ pre,
 }
 
 @media (max-width: 768px) {
+    .container {
+        padding-inline: 0;
+    }
+
+    .nav-container {
+        padding: 1rem;
+    }
+
+    .nav-links {
+        gap: 1rem;
+    }
+
     .nav-link {
         display: none;
     }
     
     .hero {
-        padding-top: 6rem;
+        min-height: auto;
+        padding: 6rem 1rem 4rem;
     }
     
     .hero-logo {
         font-size: 2.5rem;
+    }
+
+    .hero-description {
+        margin-bottom: 2rem;
+    }
+
+    .hero-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .hero-actions .btn {
+        width: 100%;
+    }
+
+    .install-command {
+        font-size: 0.92rem;
+        padding: 1rem;
+    }
+
+    .quickstart-step p,
+    .quickstart-footer {
+        overflow-wrap: anywhere;
+    }
+
+    .quickstart-step code,
+    .quickstart-footer code {
+        word-break: break-word;
     }
     
     .code-box-content {
@@ -2205,9 +2288,73 @@ pre,
     .quickstart, .stats-panel, .features, .services, .faq, .cta {
         padding: 0 1rem 4rem;
     }
+
+    .section-divider {
+        margin-bottom: 3rem;
+    }
     
     .features-grid, .services-grid, .stats-grid, .depth-grid {
         grid-template-columns: 1fr;
+    }
+
+    .stat-card-header {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .stat-source {
+        white-space: normal;
+    }
+
+    .agents-explorer {
+        grid-template-columns: 1fr;
+        height: auto;
+        max-height: none;
+        min-height: 0;
+        overflow: visible;
+    }
+
+    .agents-tree-pane {
+        border-bottom: 1px solid var(--border);
+        border-right: 0;
+        max-height: 22rem;
+        padding: 0.9rem;
+    }
+
+    .agents-tree-item {
+        line-height: 1.35;
+        overflow-wrap: anywhere;
+        white-space: normal;
+    }
+
+    .agents-content-pane {
+        max-height: none;
+    }
+
+    .agents-content-header {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.45rem;
+        padding: 0.85rem 0.9rem;
+    }
+
+    .agents-content-header span {
+        overflow: visible;
+        overflow-wrap: anywhere;
+        text-overflow: clip;
+        white-space: normal;
+    }
+
+    .agents-content {
+        max-height: min(58vh, 32rem);
+        padding: 0.9rem;
+        word-break: break-word;
+    }
+
+    .agents-content-item {
+        white-space: normal;
+        width: auto;
     }
 
     .capability-strip {
@@ -2216,8 +2363,121 @@ pre,
 }
 
 @media (max-width: 520px) {
+    .nav-logo {
+        font-size: 1.1rem;
+    }
+
+    .theme-toggle {
+        padding: 0.45rem;
+    }
+
+    .install-header {
+        gap: 0.65rem;
+        padding: 0.65rem 0.75rem;
+    }
+
+    .install-dots {
+        gap: 0.35rem;
+    }
+
+    .install-tabs {
+        margin-left: 0;
+    }
+
+    .install-tab {
+        padding: 0.3rem 0.55rem;
+    }
+
+    .btn {
+        font-size: 1rem;
+        padding: 0.9rem 1rem;
+    }
+
+    .btn-primary {
+        padding-left: 2.75rem;
+    }
+
+    .btn-primary .btn-icon-left {
+        left: 1rem;
+    }
+
+    .btn-secondary {
+        flex-wrap: wrap;
+        gap: 0.45rem;
+    }
+
+    .quickstart-step {
+        gap: 0.9rem;
+    }
+
+    .step-number {
+        height: 2.15rem;
+        width: 2.15rem;
+    }
+
+    .stat-card,
+    .feature-card,
+    .faq-item {
+        border-radius: 14px;
+        padding: 1rem;
+    }
+
+    .monthly-chart {
+        gap: 0.5rem;
+        min-height: 220px;
+        padding-top: 0.75rem;
+    }
+
+    .monthly-group {
+        flex-basis: 2.35rem;
+        gap: 0.35rem;
+    }
+
+    .monthly-bars {
+        gap: 0.18rem;
+        height: 160px;
+    }
+
+    .monthly-bar {
+        width: 0.85rem;
+    }
+
+    .monthly-label {
+        font-size: 0.62rem;
+    }
+
+    .commit-chart {
+        min-height: 190px;
+    }
+
+    .agents-explorer {
+        border-radius: 14px;
+    }
+
+    .agents-tree-pane {
+        max-height: 19rem;
+    }
+
+    .agents-content {
+        font-size: 0.76rem;
+        max-height: 55vh;
+    }
+
     .capability-strip {
         grid-template-columns: 1fr;
+    }
+
+    .services-grid {
+        gap: 1.35rem;
+    }
+
+    .docs-content pre {
+        padding: 0.85rem;
+    }
+
+    .docs-content table {
+        display: block;
+        overflow-x: auto;
     }
 }
 


### PR DESCRIPTION
## Summary

- Tighten mobile gutters, wrapping, and tap-target sizing for the homepage layout.
- Stack the `.agents` file browser on mobile so the tree and preview panes no longer clip horizontally.
- Keep stats/chart overflow contained inside cards and document the responsive rules in `DESIGN.md`.
- Bump the stylesheet cache query so the released responsive CSS is fetched by visitors.

## Review context

Files changed:

- `styles.css`: responsive containment, chart/card wrapping, mobile breakpoints, `.agents` browser stacking.
- `index.html`: stylesheet cache-buster update from `v=13` to `v=14`.
- `DESIGN.md`: mobile layout rules for future visual changes.

## Verification

- `node --check script.js`
- `python3 -m json.tool data/aidevops-stats.json >/dev/null`
- `python3 -m json.tool site.webmanifest >/dev/null`
- `python3 -m html.parser index.html >/dev/null`
- `git diff --check`
- `magick identify og-image.svg og-image.png favicon.svg favicon-16x16.png favicon-32x32.png favicon-48x48.png apple-touch-icon.png android-chrome-192x192.png android-chrome-512x512.png favicon.ico`
- Headless Chrome responsive audit at `320`, `360`, `390`, `414`, and `768` px: `documentElement.scrollWidth` matched viewport width and no horizontal overflow offenders were reported.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.47 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 28m and 300,477 tokens on this with the user in an interactive session.