### PR TITLE
docs: add social graph preview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 # aidevops.sh
 
+![AI DevOps social graph preview](./og-image.png)
+
 Static website for the [AI DevOps Framework](https://github.com/marcusquinn/aidevops).
 
 **Live site:** [aidevops.sh](https://aidevops.sh)
 
 ## About
 
-This repository contains the static website for AI DevOps - a framework that transforms your AI assistant into a powerful infrastructure management tool with 30+ service integrations.
+This repository contains the static website for AI DevOps - a framework that
+transforms your AI assistant into a powerful infrastructure management tool with
+30+ service integrations.
 
 ## Auto-sync
 
-The `docs.html` page is automatically generated from the [aidevops README.md](https://github.com/marcusquinn/aidevops/blob/main/README.md) via GitHub Actions on each release.
+The `docs.html` page is automatically generated from the
+[aidevops README.md](https://github.com/marcusquinn/aidevops/blob/main/README.md)
+via GitHub Actions on each release.
 
 ## Local Development
 


### PR DESCRIPTION
## Summary

- Adds the existing `og-image.png` social graph preview to the top of `README.md`.
- Wraps existing long README lines so Markdown lint passes.

## Verification

- `python3 -m py_compile scripts/update_site_stats.py`
- `markdownlint README.md`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.47 plugin for [OpenCode](https://opencode.ai) v1.17.13
