### PR TITLE
fix: polish mobile charts and nav

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -133,6 +133,9 @@ magick favicon-16x16.png favicon-32x32.png favicon-48x48.png favicon.ico
 - Section gutters collapse to the section padding at tablet/mobile widths so cards keep enough internal space.
 - Stats card headings and source pills stack on mobile; source text may wrap instead of forcing card overflow.
 - Chart cards keep horizontal scroll contained within `.monthly-chart`; the whole page should remain width-safe at `320`, `360`, `390`, `414`, and `768` pixel viewports.
+- Monthly bar charts must reserve enough vertical clearance for the tallest generated stack so rounded bar tops and glow are not clipped.
+- Dense line charts should sit inside their own horizontal scroll wrapper on mobile instead of scaling until labels and peaks are unreadable.
+- Mobile navigation should preserve Docs, GitHub, social, and theme actions as compact icon buttons rather than dropping links.
 - The `.agents` file browser stacks tree above content on mobile. Search paths, breadcrumbs, file names, and preview text wrap within the card rather than clipping behind the right edge.
 - Install commands, quickstart command snippets, service links, and other long strings should use wrapping/word-break rules that preserve tap targets and readability.
 

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     <meta name="apple-mobile-web-app-title" content="AI DevOps">
     <meta name="application-name" content="AI DevOps">
     
-    <link rel="stylesheet" href="styles.css?v=14">
+    <link rel="stylesheet" href="styles.css?v=15">
     
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=5">
@@ -224,7 +224,12 @@
         <div class="nav-container">
             <a href="/" class="nav-logo"><svg class="nav-logo-icon" viewBox="0 0 576 512" width="20" height="20"><path fill="currentColor" d="M9.4 86.6C-3.1 74.1-3.1 53.9 9.4 41.4s32.8-12.5 45.3 0l192 192c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L178.7 256 9.4 86.6zM256 416H544c17.7 0 32 14.3 32 32s-14.3 32-32 32H256c-17.7 0-32-14.3-32-32s14.3-32 32-32z"/></svg>aidevops</a>
             <div class="nav-links">
-                <a href="docs.html" class="nav-link">Docs</a>
+                <a href="docs.html" class="nav-link" aria-label="Read the Docs">
+                    <svg class="nav-link-icon" viewBox="0 0 24 24" width="20" height="20" fill="currentColor" aria-hidden="true">
+                        <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"/>
+                    </svg>
+                    <span class="nav-link-label">Docs</span>
+                </a>
                 <a href="https://github.com/marcusquinn/aidevops" target="_blank" rel="noopener noreferrer" class="btn-nav" aria-label="View on GitHub">
                     <span class="btn-icon-left">
                         <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
@@ -439,7 +444,9 @@
                             <span class="stat-label" id="commitsHeading">Commits per day</span>
                             <span class="stat-source" id="commitsSource">loading</span>
                         </div>
-                        <svg class="commit-chart" id="commitChart" viewBox="0 0 900 260" role="img" aria-label="Commits per day over the repository lifetime"></svg>
+                        <div class="commit-chart-scroll" tabindex="0" aria-label="Scrollable commits per day chart">
+                            <svg class="commit-chart" id="commitChart" viewBox="0 0 900 260" role="img" aria-label="Commits per day over the repository lifetime"></svg>
+                        </div>
                     </article>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -144,11 +144,13 @@ pre,
     margin: 0 auto;
     padding: 1rem 1.5rem;
     display: flex;
+    gap: 1rem;
     justify-content: space-between;
     align-items: center;
 }
 
 .nav-logo {
+    flex: 0 1 auto;
     font-size: 1.25rem;
     font-weight: 700;
     color: var(--text-primary);
@@ -158,6 +160,8 @@ pre,
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    min-width: 0;
+    white-space: nowrap;
 }
 
 .nav-logo-icon {
@@ -176,14 +180,22 @@ pre,
 .nav-links {
     display: flex;
     align-items: center;
+    flex: 0 0 auto;
     gap: 1.5rem;
 }
 
 .nav-link {
+    align-items: center;
     color: var(--text-muted);
+    display: inline-flex;
+    gap: 0.35rem;
     text-decoration: none;
     font-size: 0.9rem;
     transition: color 0.2s;
+}
+
+.nav-link-icon {
+    display: none;
 }
 
 .nav-link:hover {
@@ -1091,13 +1103,14 @@ pre,
 
 .monthly-chart {
     align-items: end;
+    contain: paint;
     display: flex;
     gap: 0.85rem;
     max-width: 100%;
-    min-height: 260px;
+    min-height: 300px;
     overscroll-behavior-x: contain;
     overflow-x: auto;
-    padding: 1rem 0.25rem 0.5rem;
+    padding: 1.25rem 0.25rem 0.5rem;
     scrollbar-width: thin;
 }
 
@@ -1142,7 +1155,7 @@ pre,
     align-items: end;
     display: flex;
     gap: 0.25rem;
-    height: 190px;
+    height: 13.5rem;
 }
 
 .monthly-bar {
@@ -1197,6 +1210,16 @@ pre,
     min-height: 260px;
     overflow: visible;
     width: 100%;
+}
+
+.commit-chart-scroll {
+    border-radius: 14px;
+    contain: paint;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    scrollbar-width: thin;
 }
 
 .commit-chart text {
@@ -2232,15 +2255,74 @@ pre,
     }
 
     .nav-container {
-        padding: 1rem;
+        gap: 0.75rem;
+        padding: 0.85rem 1rem;
     }
 
     .nav-links {
-        gap: 1rem;
+        gap: 0.5rem;
     }
 
     .nav-link {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        height: 2.5rem;
+        justify-content: center;
+        padding: 0;
+        width: 2.5rem;
+    }
+
+    .nav-link:hover,
+    .nav-link:focus-visible {
+        border-color: var(--border-hover);
+        color: var(--text-primary);
+    }
+
+    .nav-link-icon {
+        display: block;
+    }
+
+    .nav-link-label,
+    .btn-nav .btn-text,
+    .btn-nav .btn-icon-right {
         display: none;
+    }
+
+    .btn-nav {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        display: inline-flex;
+        height: 2.5rem;
+        padding: 0;
+        width: 2.5rem;
+    }
+
+    .btn-nav .btn-icon-left {
+        left: auto;
+        position: static;
+    }
+
+    .btn-nav:hover .btn-icon-left {
+        filter: none;
+        opacity: 1;
+        transform: none;
+    }
+
+    .nav-icon,
+    .theme-toggle {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        height: 2.5rem;
+        justify-content: center;
+        padding: 0;
+        width: 2.5rem;
+    }
+
+    .nav-icon:hover,
+    .nav-icon:focus-visible,
+    .theme-toggle:hover,
+    .theme-toggle:focus-visible {
+        border-color: var(--border-hover);
     }
     
     .hero {
@@ -2307,6 +2389,10 @@ pre,
         white-space: normal;
     }
 
+    .commit-chart {
+        min-width: 720px;
+    }
+
     .agents-explorer {
         grid-template-columns: 1fr;
         height: auto;
@@ -2364,11 +2450,25 @@ pre,
 
 @media (max-width: 520px) {
     .nav-logo {
-        font-size: 1.1rem;
+        font-size: 1rem;
     }
 
+    .nav-links {
+        gap: 0.35rem;
+    }
+
+    .nav-link,
+    .btn-nav,
+    .nav-icon,
     .theme-toggle {
-        padding: 0.45rem;
+        height: 2.25rem;
+        width: 2.25rem;
+    }
+
+    .nav-link-icon,
+    .nav-links svg {
+        height: 1.1rem;
+        width: 1.1rem;
     }
 
     .install-header {
@@ -2424,8 +2524,8 @@ pre,
 
     .monthly-chart {
         gap: 0.5rem;
-        min-height: 220px;
-        padding-top: 0.75rem;
+        min-height: 280px;
+        padding-top: 1rem;
     }
 
     .monthly-group {
@@ -2434,8 +2534,8 @@ pre,
     }
 
     .monthly-bars {
-        gap: 0.18rem;
-        height: 160px;
+        gap: 0.09rem;
+        height: 12.25rem;
     }
 
     .monthly-bar {
@@ -2446,8 +2546,13 @@ pre,
         font-size: 0.62rem;
     }
 
+    .monthly-shape {
+        height: 0.54rem;
+    }
+
     .commit-chart {
-        min-height: 190px;
+        min-height: 220px;
+        min-width: 680px;
     }
 
     .agents-explorer {


### PR DESCRIPTION
## Summary

- Add vertical clearance to monthly issue/PR bar charts so the tallest rounded stacks are not clipped.
- Wrap the commits SVG in a horizontal scroll container on mobile so the line chart remains readable instead of shrinking too far.
- Keep Docs, GitHub, social, and theme actions visible on mobile as compact icon buttons.
- Bump the stylesheet cache query to `styles.css?v=15`.

## Review context

Files changed:

- `styles.css`: chart sizing/containment, commit chart scroll wrapper styling, mobile nav icon-button rules.
- `index.html`: Docs icon markup, commit chart scroll wrapper, stylesheet cache-buster.
- `DESIGN.md`: responsive rules for chart clearance, dense chart scrolling, and mobile nav action visibility.

## Verification

- `node --check script.js`
- `python3 -m json.tool data/aidevops-stats.json >/dev/null`
- `python3 -m json.tool site.webmanifest >/dev/null`
- `python3 -m html.parser index.html >/dev/null`
- `git diff --check`
- `magick identify og-image.svg og-image.png favicon.svg favicon-16x16.png favicon-32x32.png favicon-48x48.png apple-touch-icon.png android-chrome-192x192.png android-chrome-512x512.png favicon.ico`
- Local headless Chrome responsive audit at `320`, `360`, `390`, `414`, and `768` px: 4 nav actions visible, no uncontained overflow, bar stack heights fit their containers, page horizontal scroll remains locked, and commit chart has horizontal scroll room.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.47 plugin for [OpenCode](https://opencode.ai) v1.17.13
