### PR TITLE
docs: complete light theme tokens

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,8 +35,12 @@ Use the CSS custom properties in `styles.css` as the source of truth.
 
 - Primary background: `#f7fbfc`.
 - Secondary background: `#edf6f8`.
+- Tertiary background: `#ffffff`.
 - Surface: `#ffffff`.
+- Raised surface: `#f8fdff`.
 - Primary text: `#071013`.
+- Secondary text: `rgba(7, 16, 19, 0.84)`.
+- Muted text: `rgba(7, 16, 19, 0.62)`.
 - Accent: `#0d6f84`.
 - Accent hover: `#0a8ca8`.
 - Strong accent: `#064f60`.


### PR DESCRIPTION
Resolves #142

Summary:
- Added the missing light theme design-guide tokens so DESIGN.md matches styles.css: tertiary background, raised surface, secondary text, and muted text.

Testing:
- Read styles.css light theme variables and DESIGN.md light theme section.
- Ran `npx markdownlint-cli2 DESIGN.md`; it reports existing MD013 line-length violations outside the changed token block.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 4m and 27,125 tokens on this as a headless worker.