### PR TITLE
fix: remove unused docs codeblock marker

### DIFF
--- a/script.js
+++ b/script.js
@@ -993,7 +993,6 @@
         const languageClass = Array.from(code.classList).find((className) => className.startsWith('language-')) || '';
         const isMarkdown = /language-(markdown|md)/i.test(languageClass);
         code.innerHTML = highlighter(code.textContent, { isMarkdown });
-        code.closest('pre')?.classList.add('docs-codeblock-coloured');
     });
 })();
 


### PR DESCRIPTION
## Summary
- Removed the unused `docs-codeblock-coloured` marker assignment from the docs code block highlighter.
- Verified the marker has no remaining CSS or JavaScript references.

## Testing
- `node --check script.js`
- `rg -n docs-codeblock-coloured` (expected no matches)

Resolves #137

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13
