### PR TITLE
fix: address file browser review feedback

### DIFF
--- a/script.js
+++ b/script.js
@@ -820,22 +820,26 @@
         const rows = [];
         if (path !== '.agents') {
             const parent = parentPath(path);
-            rows.push(`<a class="agents-content-item parent" href="${githubLinkForPath(parent, 'tree')}" data-path="${escapeHtml(parent)}">↰ ../</a>`);
+            rows.push(`<a class="agents-content-item parent" href="${escapeHtml(githubLinkForPath(parent, 'tree'))}" data-path="${escapeHtml(parent)}">↰ ../</a>`);
         }
         children.slice(0, 240).forEach((child) => {
             const icon = child.type === 'tree' ? '▸' : '•';
             const name = `${child.path.split('/').pop()}${child.type === 'tree' ? '/' : ''}`;
-            rows.push(`<a class="agents-content-item ${child.type === 'tree' ? 'folder' : 'file'}" href="${githubLinkForPath(child.path, child.type)}" data-path="${escapeHtml(child.path)}">${icon} ${escapeHtml(name)}</a>`);
+            rows.push(`<a class="agents-content-item ${child.type === 'tree' ? 'folder' : 'file'}" href="${escapeHtml(githubLinkForPath(child.path, child.type))}" data-path="${escapeHtml(child.path)}">${icon} ${escapeHtml(name)}</a>`);
         });
         if (children.length > 240) rows.push(`<span class="agents-directory-more">… ${children.length - 240} more items</span>`);
         setDirectoryContent(path, rows.join(''), githubLinkForPath(path, 'tree'));
         const content = $('agentsContent');
-        if (content) {
-            content.querySelectorAll('.agents-content-item').forEach((link) => {
-                link.addEventListener('click', (event) => {
-                    event.preventDefault();
-                    selectTreeItem(link.dataset.path);
-                });
+        if (content && !content.dataset.agentsContentListenerBound) {
+            content.dataset.agentsContentListenerBound = 'true';
+            content.addEventListener('click', (event) => {
+                const target = event.target instanceof Element ? event.target : event.target.parentElement;
+                const link = target?.closest('.agents-content-item');
+                if (!link || event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+                    return;
+                }
+                event.preventDefault();
+                selectTreeItem(link.dataset.path);
             });
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -1592,8 +1592,9 @@ pre,
 .agents-content-item:hover,
 .agents-content-item:focus-visible {
     color: var(--accent);
-    outline: none;
-    text-decoration-color: currentColor;
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    text-decoration-color: currentcolor;
 }
 
 .agents-content-item.folder,


### PR DESCRIPTION
## Summary
- Escapes generated file-browser `href` attributes before inserting them into HTML strings.
- Replaces per-item click listeners with a single delegated handler on the content container.
- Preserves native link behavior for modifier/non-primary clicks while keeping in-page navigation for normal clicks.
- Restores a visible focus outline and uses lowercase `currentcolor` for CSS lint compatibility.

## Testing
- `node --check script.js`

Resolves #143

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.53 plugin for [OpenCode](https://opencode.ai) v1.17.13
