### PR TITLE
fix: restore automatic homepage stats updates

### DIFF
--- a/.github/workflows/update-site-stats.yml
+++ b/.github/workflows/update-site-stats.yml
@@ -2,36 +2,55 @@ name: Update site stats
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '17 2 * * *'
 
 concurrency:
-  group: update-site-stats-${{ github.ref }}
+  group: github-pages
   cancel-in-progress: false
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   update-site-stats:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Generate site stats
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/update_site_stats.py
 
-      - name: Commit updated stats and social image metrics
+      - name: Prepare Pages artifact
         run: |
-          if git diff --quiet -- data/aidevops-stats.json og-image.svg og-image.png; then
-            echo "No site stats or social image metric changes"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/aidevops-stats.json og-image.svg og-image.png
-          git commit -m "chore: update site stats"
-          git push
+          mkdir -p _site/data
+          cp \
+            404.html CNAME _headers docs.html index.html robots.txt script.js \
+            site.webmanifest sitemap.xml styles.css favicon.svg favicon.ico \
+            favicon-16x16.png favicon-32x32.png favicon-48x48.png \
+            apple-touch-icon.png android-chrome-192x192.png \
+            android-chrome-512x512.png og-image.svg og-image.png _site/
+          cp data/aidevops-stats.json _site/data/
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- replace protected-branch stats commits with direct GitHub Pages artifact deployments
- regenerate and deploy stats daily and after every push to `main`
- grant only the read/Pages/OIDC permissions required for deployment
- update checkout to the Node 24-compatible action release

## Testing

- `actionlint .github/workflows/update-site-stats.yml`
- Ruby YAML parse
- `git diff --check`
- local Pages artifact assembly (21 expected files)
- JSON, JavaScript, and home-page HTML parsing

## Runtime Testing

Self-assessed locally. The merged workflow will be dispatched and its exact deployment verified before completion.

## Key decision

Deploy generated data as an ephemeral Pages artifact instead of writing generated files back to protected `main`; this preserves branch protection while keeping the public stats current.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.124 plugin for [OpenCode](https://opencode.ai) v1.18.2 with gpt-5.6-sol spent 5m and 124,865 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Site statistics are now published automatically through GitHub Pages deployments.
  * Statistics updates are triggered when changes are pushed to the main branch.

* **Bug Fixes**
  * Prevented automated statistics updates from creating commits or modifying repository files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->