### PR TITLE
fix: pin linked-issue workflow dependency (#155)

### DIFF
--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -22,4 +22,4 @@ on:
 
 jobs:
   check:
-    uses: marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml@main
+    uses: marcusquinn/aidevops/.github/workflows/linked-issue-check-reusable.yml@f5ac0cecd63b315a7409ed492216bb6a153b94a3


### PR DESCRIPTION
## Summary

- pin the linked-issue reusable workflow to an immutable upstream commit
- remove the mutable `@main` supply-chain boundary from the privileged caller

## Verification

- `actionlint .github/workflows/linked-issue-check.yml`
- pre-commit workflow validation

Resolves #155

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.195 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the linked-issue validation workflow to a specific version for more consistent and reliable checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->