### PR TITLE
GH#161: enforce issue-first external pull requests

### DIFF
--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -13,6 +13,7 @@ name: Linked Issue Check
 # a repository ruleset.
 
 permissions:
+  issues: read
   pull-requests: read
   statuses: write
 


### PR DESCRIPTION
## Summary

- Install `.github/workflows/linked-issue-check.yml` to validate local issue references on external pull requests.
- Add or refresh the managed issue-first policy in `CONTRIBUTING.md`.

## Why

Maintainers monitor the issue queue more consistently than unsolicited pull requests.
External contributors should create or find a local issue before opening a PR.

## Security

The workflow consumes immutable event metadata only. It does not check out, source,
or execute pull-request head content.

## Verification

- External human PR without an accepted local issue reference: check fails.
- Owner, member, collaborator, and bot PRs: documented exemptions apply.
- Re-running the rollout produces no file changes.
- Post-merge caller classification: `CURRENT/CALLER`.

**Classification before**: `DRIFTED/CALLER`  
**Ref**: `@f5ac0cecd63b315a7409ed492216bb6a153b94a3`
**Rollout task**: `GH#161`

Resolves #161

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.250 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 3m and 69,282 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request checks to read linked issue information successfully.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
